### PR TITLE
Erro de digitação de cofins

### DIFF
--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -145,7 +145,7 @@ public sealed class DanfeHtmlRenderer
         switch (tpRetPisCofins)
         {
             case 1: // 1 - PIS/COFINS Retido
-                vRetPisCofins = (vPIS ?? 0M) + (vPIS ?? 0M);
+                vRetPisCofins = (vPIS ?? 0M) + (vCOFINS ?? 0M);
                 break;
             case 2: // 2 - PIS / COFINS Não Retido
             default:


### PR DESCRIPTION
## O que foi feito
- mudando vPins para vCofins no totalizador

## Por quê
- Erro de digitação

## Como testar
- [ ] `dotnet test`
- [ ] Gere DANFSe com XML de exemplo
- [ ] Valide layout (prints ou PDF anexado)

## Checklist
- [ ] Código formatado (`dotnet format`)
- [ ] Template HTML formatado (`prettier`)
- [ ] Testes adicionados/ajustados (quando aplicável)
- [ ] Documentação/README atualizados (quando aplicável)

## Observações
-
