### PR TITLE
Ajuste totalizadores municipais

### DIFF
--- a/src/Danfe/Assets/Templates/Danfe.html
+++ b/src/Danfe/Assets/Templates/Danfe.html
@@ -722,7 +722,7 @@
               </td>
               <td style="vertical-align: top; width: 25%">
                 <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  PIS/COFINS - Débito de Apur. Própria
+                  PIS/COFINS - Débito Apur. Própria
                 </span>
                 <br />
                 {{PISCOFINS_DEB}}

--- a/src/Danfe/Internal/Helper.cs
+++ b/src/Danfe/Internal/Helper.cs
@@ -72,7 +72,7 @@ namespace Direction.NFSe.Danfe
 
             if (subst != null)
             {
-                AppendWithSeparator(sb , $"<b>NFSe Subst:</b> {subst.chSubstda}");
+                AppendWithSeparator(sb, $"<b>NFSe Subst:</b> {subst.chSubstda}");
             }
 
             if (serv.infoCompl != null)

--- a/src/Danfe/Internal/Helper.cs
+++ b/src/Danfe/Internal/Helper.cs
@@ -55,6 +55,15 @@ namespace Direction.NFSe.Danfe
             return encoded.Replace("\r\n", "<br/>").Replace("\n", "<br/>");
         }
 
+        private static void AppendWithSeparator(StringBuilder sb, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                if (sb.Length > 0) sb.Append(" | ");
+                sb.Append(value);
+            }
+        }
+
         public static string BuildInfComplementares(Servico? serv, NFSeSubstituida? subst)
         {
             if (serv?.cServ == null) return "";
@@ -63,21 +72,21 @@ namespace Direction.NFSe.Danfe
 
             if (subst != null)
             {
-                sb.Append($"<b>NFSe Subst:</b> {subst.chSubstda} | ");
+                AppendWithSeparator(sb , $"<b>NFSe Subst:</b> {subst.chSubstda}");
             }
 
             if (serv.infoCompl != null)
             {
                 if (!string.IsNullOrEmpty(serv.infoCompl.idDocTec))
-                    sb.Append($"Identificador de Responsabilidade Técnica: {serv.infoCompl.idDocTec} \n");
+                    AppendWithSeparator(sb, $"Identificador de Responsabilidade Técnica: {serv.infoCompl.idDocTec} \n");
 
                 if (!string.IsNullOrEmpty(serv.infoCompl.xInfComp))
-                    sb.Append($"<b>Inf Cont:</b> {serv.infoCompl.xInfComp} | ");
+                    AppendWithSeparator(sb, $"<b>Inf Cont:</b> {serv.infoCompl.xInfComp}");
             }
 
             if (serv.cServ.cNBS != 0)
             {
-                sb.Append($"<b>NBS:</b> {serv.cServ.cNBS}");
+                AppendWithSeparator(sb, $"<b>NBS:</b> {serv.cServ.cNBS}");
             }
 
             return sb.Length == 0 ? "-" : sb.ToString();

--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -236,12 +236,12 @@ public sealed class DanfeHtmlRenderer
             ["{{ISS_PROCESSO}}"] = DanfeFallback.OrDash(infDps.valores?.trib?.tribMun?.exigSusp?.nProcesso, warnings, "Número Processo Suspensão", "infNFSe.DPS.InfDPS.valores.trib.tribMun.exigSusp.nProcesso"),
             ["{{ISS_BENEFICIO}}"] = DanfeFallback.OrDash(infDps.valores?.trib?.tribMun?.BM?.nBM.ToString(), warnings, "Benefício Municipal", "infNFSe.DPS.InfDPS.valores.trib.tribMun.BM.nBM"),
             ["{{ISS_DESC_INCOND}}"] = DanfeFallback.OrCurrency(infDps.valores?.vDescCondIncond?.vDescIncond, ptBR, warnings, "vDescIncond", "infNFSe.valores.vDescCondIncond.vDescIncond"),
-            ["{{ISS_DEDUCOES}}"] = DanfeFallback.OrCurrency(infDps.valores?.vDedRed?.vDR, ptBR, warnings, "vDR", "infNFSe.valores.vDedRed.vDR"),
-            ["{{ISS_CALCULO}}"] = DanfeFallback.OrCurrency(infDps.valores?.trib?.tribMun?.BM?.vRedBCBM, ptBR, warnings, "vRedBCBM", "infNFSe.valores.trib.tribMun.BM.vRedBCBM"), //TO DO: verificar no futuro se Calculo do BM realmente se refere a esse campo
-            ["{{ISS_BC}}"] = (tpRetIssqn == 2 || opSimpNac == 1) ? vServico.ToString("C", ptBR) : "-",
-            ["{{ISS_ALIQ}}"] = (tpRetIssqn == 2 || opSimpNac == 1) ? DanfeFallback.OrPercent(vAliqAplic, ptBR, warnings, "pAliqAplic", "infNFSe.valores.pAliqAplic") : "-",
+            ["{{ISS_DEDUCOES}}"] = DanfeFallback.OrCurrency(inf.valores?.vCalcDR, ptBR, warnings, "vCalcDR", "nfse.infNFSe.valores.vCalcDR"),
+            ["{{ISS_CALCULO}}"] = DanfeFallback.OrCurrency(inf.valores?.vCalcBM, ptBR, warnings, "vCalcBM", "nfse.infNFSe.valores.vCalcBM"),
+            ["{{ISS_BC}}"] = DanfeFallback.OrCurrency(inf.valores?.vBC, ptBR, warnings, "vBC", "nfse.infNFSe.valores.vBC"),
+            ["{{ISS_ALIQ}}"] = DanfeFallback.OrPercent(vAliqAplic, ptBR, warnings, "pAliqAplic", "infNFSe.valores.pAliqAplic"),
             ["{{ISS_RETENCAO}}"] = GetDescricaoRetencao(tpRetIssqn),
-            ["{{ISS_APURADO}}"] = (tpRetIssqn == 2 || opSimpNac == 1) ? DanfeFallback.OrCurrency(vIssqn, ptBR, warnings, "vISSQN", "infNFSe.valores.vISSQN") : "-",
+            ["{{ISS_APURADO}}"] = DanfeFallback.OrCurrency(vIssqn, ptBR, warnings, "vISSQN", "infNFSe.valores.vISSQN"),
 
             // Tributação Federal
             ["{{FED_IRRF}}"] = DanfeFallback.OrCurrency(vIRRF, ptBR, warnings, "vIRRF", "infDps.valores.trib.tribFed.vRetIRRF"),

--- a/src/Danfe/Schemas/NFSeSchema.cs
+++ b/src/Danfe/Schemas/NFSeSchema.cs
@@ -364,7 +364,7 @@ namespace Direction.NFSe.Danfe
 
     public class BM
     {
-        public int nBM { get; set; }
+        public long nBM { get; set; }
         public decimal? vRedBCBM { get; set; }
         public decimal? pRedBCBM { get; set; }
         public int tpRetISSQN { get; set; }


### PR DESCRIPTION
## O que foi feito
- Ajustando descrição visual do campo PIS/COFINS de apuração própria
- Tornando **nBM** um numeral do tipo **long**
- Ajustando o preenchimento dos totalizadores de impostos municipais
- Ajustando preenchimento de informações complementares da nota

## Por quê
- Houve divergências entre o que o projeto estava gerando e o que o Ambiente Nacional estava gerando

## Como testar
- [ ] `dotnet test`
- [ ] Gere DANFSe com XML de exemplo
- [ ] Valide layout (prints ou PDF anexado)

## Checklist
- [ ] Código formatado (`dotnet format`)
- [ ] Template HTML formatado (`prettier`)
- [ ] Testes adicionados/ajustados (quando aplicável)
- [ ] Documentação/README atualizados (quando aplicável)

## Observações
- Os ajustes  podem ter interferido na exibição de notas antigas
