### PR TITLE
FIX - ajusta o modo em que é identificado se a nota foi substituída

### DIFF
--- a/src/Danfe/Public/DanfeService.cs
+++ b/src/Danfe/Public/DanfeService.cs
@@ -16,9 +16,9 @@ public sealed class DanfeService
         _pdf = new DanfePdfGenerator(converter);
     }
 
-    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
-        var (html, warnings) = _renderer.Render(nfse, environment, isCancelled);
+        var (html, warnings) = _renderer.Render(nfse, environment, status);
         var pdfBytes = _pdf.Generate(html);
 
         return new DanfeResult
@@ -30,18 +30,18 @@ public sealed class DanfeService
         };
     }
 
-    public DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(string xml, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
         using var sr = new StringReader(xml);
         var nfse = Deserialize(sr);
-        return Generate(nfse, environment, isCancelled);
+        return Generate(nfse, environment, status);
     }
 
-    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
         using var sr = new StreamReader(xmlStream);
         var nfse = Deserialize(sr);
-        return Generate(nfse, environment, isCancelled);
+        return Generate(nfse, environment, status);
     }
 
     private static NFSeSchema Deserialize(TextReader reader)

--- a/src/Danfe/Public/DanfeStatus.cs
+++ b/src/Danfe/Public/DanfeStatus.cs
@@ -1,0 +1,8 @@
+namespace Direction.NFSe.Danfe;
+
+public enum DanfeStatus
+{
+    Autorizada,
+    Cancelada,
+    Substituida
+}

--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -23,7 +23,7 @@ public sealed class DanfeHtmlRenderer
         _templatePath = _options.TemplatePath ?? Path.Combine(basePath, "Assets", "Templates", "Danfe.html");
     }
 
-    public (string Html, IReadOnlyList<DanfeWarning> Warnings) Render(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled = false)
+    public (string Html, IReadOnlyList<DanfeWarning> Warnings) Render(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status)
     {
         if (nfse == null) throw new ArgumentNullException(nameof(nfse));
         if (nfse.infNFSe == null) throw new ArgumentException("NFSe.infNFSe não pode ser nulo", nameof(nfse));
@@ -143,6 +143,7 @@ public sealed class DanfeHtmlRenderer
         decimal vDebPisCofins = (vPIS ?? 0M) + (vCOFINS ?? 0M);
 
         // Verifica se a NFSe está cancelada
+        var isCancelled = status == DanfeStatus.Cancelada;
         string canceladaDiv = isCancelled
             ? @"<div style=""
               position:absolute;
@@ -167,7 +168,7 @@ public sealed class DanfeHtmlRenderer
             : string.Empty;
 
         // Verifica se a NFSe foi substituída e não cancelada
-        var isSubstituida = infDps.subst != null && !isCancelled;
+        var isSubstituida = status == DanfeStatus.Substituida;
         string substituidaDiv = isSubstituida
             ? @"<div style=""
               position:absolute;


### PR DESCRIPTION
## O que foi feito
Inclui Enum para identificação de nota cancelada / substituída. Também ajusta o código para o usuário tenha a customização desse parametro.

## Por quê
Do jeito que o código estava, ele identificava se existia a tag <subst> no XML, para enfim classificá-lo como substituído.
Isso é errado, pois quando o XML possui essa tag, isso quer dizer que o XML é **substituto** de um outro, que pode ser identificado pelos dados dentro do campo.
Hoje em dia é necessário fazer essa identificação de cancelada/substituída via eventos do DFe. Então tornando a opção de cancelado e substituído customizável ajuda com aqueles que utilizam a biblioteca para a geração de DANFSe e que já possuem tais eventos.
