### PR TITLE
Ajusta a identificação de substituição de notas e a compatibilidade de assinaturas.

### DIFF
--- a/src/Danfe/Public/DanfeService.cs
+++ b/src/Danfe/Public/DanfeService.cs
@@ -16,9 +16,9 @@ public sealed class DanfeService
         _pdf = new DanfePdfGenerator(converter);
     }
 
-    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
-        var (html, warnings) = _renderer.Render(nfse, environment, isCancelled);
+        var (html, warnings) = _renderer.Render(nfse, environment, status);
         var pdfBytes = _pdf.Generate(html);
 
         return new DanfeResult
@@ -30,18 +30,18 @@ public sealed class DanfeService
         };
     }
 
-    public DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(string xml, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
         using var sr = new StringReader(xml);
         var nfse = Deserialize(sr);
-        return Generate(nfse, environment, isCancelled);
+        return Generate(nfse, environment, status);
     }
 
-    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
     {
         using var sr = new StreamReader(xmlStream);
         var nfse = Deserialize(sr);
-        return Generate(nfse, environment, isCancelled);
+        return Generate(nfse, environment, status);
     }
 
     private static NFSeSchema Deserialize(TextReader reader)

--- a/src/Danfe/Public/DanfeService.cs
+++ b/src/Danfe/Public/DanfeService.cs
@@ -16,8 +16,24 @@ public sealed class DanfeService
         _pdf = new DanfePdfGenerator(converter);
     }
 
-    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
+    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada)
     {
+        var (html, warnings) = _renderer.RenderInternal(nfse, environment, status);
+        var pdfBytes = _pdf.Generate(html);
+
+        return new DanfeResult
+        {
+            Environment = environment,
+            Html = html,
+            PdfBytes = pdfBytes,
+            Warnings = warnings
+        };
+    }
+    [Obsolete("Use Generate(NFSeSchema, DanfeEnvironment, DanfeStatus)")]
+    public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled)
+    {
+        var status = isCancelled ? DanfeStatus.Cancelada : DanfeStatus.Autorizada;
+
         var (html, warnings) = _renderer.Render(nfse, environment, status);
         var pdfBytes = _pdf.Generate(html);
 
@@ -30,18 +46,32 @@ public sealed class DanfeService
         };
     }
 
-    public DanfeResult Generate(string xml, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
+    public DanfeResult Generate(string xml, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada)
     {
         using var sr = new StringReader(xml);
         var nfse = Deserialize(sr);
         return Generate(nfse, environment, status);
     }
+    [Obsolete("Use Generate(string, DanfeEnvironment, DanfeStatus).")]
+    public DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled = false)
+    {
+        using var sr = new StringReader(xml);
+        var nfse = Deserialize(sr);
+        return Generate(nfse, environment, isCancelled);
+    }
 
-    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, DanfeStatus status  = DanfeStatus.Autorizada)
+    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada)
     {
         using var sr = new StreamReader(xmlStream);
         var nfse = Deserialize(sr);
         return Generate(nfse, environment, status);
+    }
+    [Obsolete("Use Generate(Stream, DanfeEnvironment, DanfeStatus).")]
+    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled = false)
+    {
+        using var sr = new StreamReader(xmlStream);
+        var nfse = Deserialize(sr);
+        return Generate(nfse, environment, isCancelled);
     }
 
     private static NFSeSchema Deserialize(TextReader reader)

--- a/src/Danfe/Public/DanfeStatus.cs
+++ b/src/Danfe/Public/DanfeStatus.cs
@@ -1,0 +1,8 @@
+namespace Direction.NFSe.Danfe;
+
+public enum DanfeStatus
+{
+    Autorizada,
+    Cancelada,
+    Substituida
+}

--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -23,7 +23,7 @@ public sealed class DanfeHtmlRenderer
         _templatePath = _options.TemplatePath ?? Path.Combine(basePath, "Assets", "Templates", "Danfe.html");
     }
 
-    public (string Html, IReadOnlyList<DanfeWarning> Warnings) Render(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled = false)
+    public (string Html, IReadOnlyList<DanfeWarning> Warnings) Render(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status)
     {
         if (nfse == null) throw new ArgumentNullException(nameof(nfse));
         if (nfse.infNFSe == null) throw new ArgumentException("NFSe.infNFSe não pode ser nulo", nameof(nfse));
@@ -143,6 +143,7 @@ public sealed class DanfeHtmlRenderer
         decimal vDebPisCofins = (vPIS ?? 0M) + (vCOFINS ?? 0M);
 
         // Verifica se a NFSe está cancelada
+        var isCancelled = status == DanfeStatus.Cancelada;
         string canceladaDiv = isCancelled
             ? @"<div style=""
               position:absolute;
@@ -167,7 +168,7 @@ public sealed class DanfeHtmlRenderer
             : string.Empty;
 
         // Verifica se a NFSe foi substituída e não cancelada
-        var isSubstituida = infDps.subst != null && !isCancelled;
+        var isSubstituida = status == DanfeStatus.Substituida;
         string substituidaDiv = isSubstituida
             ? @"<div style=""
               position:absolute;

--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -23,6 +23,10 @@ public sealed class DanfeHtmlRenderer
         _templatePath = _options.TemplatePath ?? Path.Combine(basePath, "Assets", "Templates", "Danfe.html");
     }
 
+    public (string Html, IReadOnlyList<DanfeWarning> Warnings) RenderInternal(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status)
+    {
+        return Render(nfse, environment, status);
+    }
     public (string Html, IReadOnlyList<DanfeWarning> Warnings) Render(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status)
     {
         if (nfse == null) throw new ArgumentNullException(nameof(nfse));


### PR DESCRIPTION
## O que foi feito
Ajuste na forma de identificar notas substituídas.

## Por quê
A implementação anterior estava incorreta. Foi corrigida mantendo a compatibilidade com versões antigas. Foram feitos testes para validar o comportamento.

## Observação
Ajuste feito com focoem compatiblida.

