### PR TITLE
Adiciona DANFSe v2 e compatibilidade com Linux

### DIFF
--- a/src/Danfe/Assets/Templates/Danfe.html
+++ b/src/Danfe/Assets/Templates/Danfe.html
@@ -1,796 +1,727 @@
 <!doctype html>
-
-<html>
+<html lang="pt-BR">
   <head>
     <meta charset="utf-8" />
-    <title>DANFSe</title>
+    <title>DANFSe v2.0</title>
+    <style>
+      @page {
+        size: A4 portrait;
+        margin: 0;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+        -webkit-print-color-adjust: exact;
+      }
+      html,
+      body {
+        width: 210mm;
+        min-height: 297mm;
+        background: #fff;
+        color: #000;
+      }
+      body {
+        font-family: "Microsoft Sans Serif", "Liberation Sans", Tahoma, Arial, sans-serif;
+        font-size: 7pt;
+        line-height: 1.15;
+      }
+      .folha {
+        position: relative;
+        width: 210mm;
+        min-height: 297mm;
+        padding: 1.8mm;
+      }
+      .danfse-frame {
+        position: relative;
+        width: 100%;
+        height: 293.4mm;
+        border: 1pt solid #000;
+        overflow: hidden;
+      }
+      table.danfse {
+        width: 100%;
+        border: 0;
+        border-collapse: collapse;
+        table-layout: fixed;
+      }
+      table.danfse td {
+        border: 0;
+        vertical-align: top;
+        padding: 1pt 2pt;
+        overflow: hidden;
+      }
+      .c {
+        height: 6mm;
+      }
+      .lbl {
+        display: block;
+        font-family: Arial, "Liberation Sans", Helvetica, sans-serif;
+        font-size: 6pt;
+        font-weight: bold;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .val {
+        display: block;
+        font-size: 7pt;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .val.wrap {
+        white-space: normal;
+        word-break: break-word;
+      }
+      .ident-row .lbl {
+        font-size: 7pt;
+        text-transform: uppercase;
+      }
+      .sec-title td {
+        border-top: 0.5pt solid #000 !important;
+        height: 6.3mm;
+      }
+      .sec-title-label {
+        width: 25%;
+        background: #f2f2f2;
+        font-family: Arial, "Liberation Sans", Helvetica, sans-serif;
+        font-size: 7pt;
+        font-weight: bold;
+        text-transform: uppercase;
+        vertical-align: middle !important;
+      }
+      .bg-cinza {
+        background: #f2f2f2;
+      }
+      .cab {
+        height: 12mm;
+        vertical-align: middle !important;
+        border-bottom: 0.5pt solid #000 !important;
+        background: #f2f2f2;
+      }
+      .cab-logo {
+        width: 25%;
+        text-align: center;
+      }
+      .cab-logo img {
+        max-width: 40mm;
+        max-height: 8.5mm;
+      }
+      .cab-titulo {
+        width: 50%;
+        text-align: center;
+        font-family: Arial, "Liberation Sans", Helvetica, sans-serif;
+        font-size: 9pt;
+        font-weight: bold;
+        line-height: 1.25;
+      }
+      .cab-titulo .sub {
+        font-size: 9pt;
+      }
+      .cab-titulo .val-jur {
+        color: #e30613;
+        font-size: 9pt;
+      }
+      .cab-info {
+        width: 25%;
+        font-size: 6pt;
+        line-height: 1.25;
+      }
+      .cab-info .municipio {
+        font-size: 8pt;
+      }
+      .c-qr {
+        width: 25%;
+        text-align: center;
+        vertical-align: top !important;
+        padding-top: 2mm !important;
+      }
+      /* Compensa a conversão de unidades do wkhtmltopdf e mantém o QR renderizado >= 15,2 mm. */
+      .c-qr img {
+        width: 15.4mm;
+        height: 15.4mm;
+      }
+      .c-qr .qr-txt {
+        margin: 1mm auto 0;
+        width: 42mm;
+        font-size: 6pt;
+        line-height: 1.1;
+        white-space: normal;
+      }
+      .supr {
+        height: 3.2mm;
+        vertical-align: middle !important;
+        padding: 0 3pt !important;
+        border-top: 0.5pt solid #000 !important;
+        text-align: center;
+        font-size: 6pt;
+        color: #000;
+      }
+      .iss-nao-sujeita {
+        height: 3.2mm;
+        vertical-align: middle !important;
+        border-top: 0.5pt solid #000 !important;
+        text-align: center;
+        font-family: Arial, "Liberation Sans", Helvetica, sans-serif;
+        font-size: 7pt;
+        font-weight: bold;
+      }
+      .desc-tributacao {
+        min-height: 4mm;
+        height: auto;
+      }
+      .desc-servico {
+        min-height: 9mm;
+        height: auto;
+      }
+      .info-compl {
+        min-height: 17mm;
+        height: auto;
+      }
+      .canhoto {
+        position: absolute;
+        right: 0;
+        bottom: 7.5mm;
+        left: 0;
+        width: 100%;
+        border-collapse: collapse;
+        table-layout: fixed;
+      }
+      .canhoto td {
+        height: 6mm;
+        border: 0.5pt solid #000 !important;
+        padding: 1pt 3pt !important;
+      }
+      .canhoto .lbl {
+        font-size: 6pt;
+        text-transform: uppercase;
+      }
+      .canhoto .val {
+        font-size: 7pt;
+      }
+    </style>
   </head>
-  <body
-    style="
-      font-family: {{FONT_FAMILY}}
-      font-size: {{FONT_SIZE}}
-      margin: 0;
-      padding: 0;
-      margin: 5px;
-      border: 2px solid #000;
-    "
-  >
-    <div class="page" style="width: 100%; margin: 0 auto">
-      <!--div de CANCELADA -->
-      {{NFSE_CANCELADA_DIV}}
-      <!-- CABEÇALHO -->
-      <!--div de SUBSTITUIDA -->
-      {{NFSE_SUBSTITUIDA_DIV}}
-      <!-- CABEÇALHO -->
-      <div class="section" style="border-bottom: none; margin-top: 4px; margin-bottom: -10px">
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="width: 30%; vertical-align: top">
-                <img
-                  style="padding: 6px 0px 6px 5px; width: auto; height: 40px"
-                  alt="Logo"
-                  class="nfse-logo"
-                  src="data:image/png;base64,{{NFSE_LOGO}}"
-                />
-              </td>
-              <td style="width: 40%; vertical-align: top; text-align: center">
-                <div class="title-main" style="font-size: 15px; font-weight: bold">DANFSe v1.0</div>
-                <div class="title-main" style="font-size: 15px; font-weight: bold">Documento Auxiliar da NFS-e</div>
-                <div
-                  class="big-title-warning"
-                  style="font-size: 15px; font-weight: bold; color: red; margin-bottom: 2px"
-                >
-                  {{VALIDADE_JURIDICA}}
-                  <br />
-                </div>
-              </td>
-              <td style="width: 30%; vertical-align: top">
-                <table cellspacing="0" cellpadding="0">
-                  <tr>
-                    <td style="vertical-align: top">
-                      <img
-                        style="width: auto; height: 50px; margin-top: 2px; margin-right: 10px"
-                        class="prefeitura-logo"
-                        src="data:image/png;base64,{{PREFEITURA_LOGO}}"
-                      />
-                    </td>
-                    <td style="width: 6px">&nbsp;</td>
-
-                    <td style="vertical-align: top; font-size: 12px">{{LOGO_NAME}}</td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- CHAVE DE ACESSO -->
-      <div class="section">
-        <div
-          class="section-title"
-          style="
-            padding: 4px 6px;
-            font-size: {{FONT_SIZE}}
-            text-transform: uppercase;
-            text-transform: none;
-            margin-bottom: -5px;
-            margin-left: 3px;
-			      font-weight: bold;
-          "
-        >
-          Chave de Acesso da NFS-e
-        </div>
-        <table style="width: 100%; border-collapse: collapse">
+  <body>
+    <div class="folha">
+      {{NFSE_CANCELADA_DIV}} {{NFSE_SUBSTITUIDA_DIV}}
+      <div class="danfse-frame">
+        <table class="danfse">
+          <colgroup>
+            <col style="width: 25%" />
+            <col style="width: 25%" />
+            <col style="width: 25%" />
+            <col style="width: 25%" />
+          </colgroup>
           <tr>
-            <td style="vertical-align: top; width: 75%">
-              <div style="margin-left: 8px; margin-bottom: 5px">{{CHAVE_ACESSO}}</div>
-              <div class="section-content" style="padding: 1px 6px 0px 6px">
-                <table style="width: 100%; border-collapse: collapse; margin-top: 7px">
-                  <tr>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Número da NFS-e
-                        </span>
-                        <br />
-                        {{NUMERO_NFSE}}
-                      </div>
-                    </td>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Competência da NFS-e
-                        </span>
-                        <br />
-                        {{COMPETENCIA}}
-                      </div>
-                    </td>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Data e Hora da emissão da NFS-e
-                        </span>
-                        <br />
-                        {{DATA_HORA_EMISSAO}}
-                      </div>
-                    </td>
-                  </tr>
-                </table>
-                <table style="width: 100%; border-collapse: collapse; margin-top: 7px">
-                  <tr>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Número da DPS
-                        </span>
-                        <br />
-                        {{NUMERO_DPS}}
-                      </div>
-                    </td>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Série da DPS
-                        </span>
-                        <br />
-                        {{SERIE_DPS}}
-                      </div>
-                    </td>
-                    <td style="vertical-align: top; width: 25%">
-                      <div>
-                        <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                          Data e Hora da emissão da DPS
-                        </span>
-                        <br />
-                        {{DATA_HORA_EMISSAO_DPS}}
-                      </div>
-                    </td>
-                  </tr>
-                </table>
-              </div>
+            <td class="cab cab-logo"><img src="data:image/png;base64,{{NFSE_LOGO}}" alt="NFS-e" /></td>
+            <td class="cab cab-titulo" colspan="2">
+              <div>DANFSe v2.0</div>
+              <div class="sub">Documento Auxiliar da NFS-e</div>
+              <div class="val-jur">{{VALIDADE_JURIDICA}}</div>
             </td>
-            <td style="vertical-align: top; width: 25%; text-align: center">
-              <div
-                class="qrcode-container"
-                style="
-                  margin-top: -15px;
-                  width: 80px;
-                  height: 80px;
-                  margin-left: auto;
-                  margin-right: auto;
-                  margin-top: -10px;
-                  font-weight: bold;
-                "
-              >
-                <img alt="Logo" class="qrcode" src="{{QRCODE_SRC}}" style="width: 100%; height: 100%" />
-              </div>
-              <div style="font-size: {{FONT_SIZE_QRCODE}}; text-align: left">
+            <td class="cab cab-info">
+              <span class="municipio">Município: {{MUNICIPIO_EMITENTE}}</span>
+              <br />
+              Ambiente Gerador: {{AMBIENTE_GERADOR}}
+              <br />
+              Tipo de Ambiente: {{TIPO_AMBIENTE}}
+            </td>
+          </tr>
+
+          <tr class="ident-row">
+            <td class="c" colspan="3">
+              <span class="lbl">CHAVE DE ACESSO DA NFS-e</span>
+              <span class="val">{{CHAVE_ACESSO}}</span>
+            </td>
+            <td class="c-qr" rowspan="4">
+              <img src="{{QRCODE_SRC}}" alt="QR Code" />
+              <div class="qr-txt">
                 A autenticidade desta NFS-e pode ser verificada pela leitura deste código QR ou pela consulta da chave
                 de acesso no portal nacional da NFS-e
               </div>
             </td>
           </tr>
+          <tr class="ident-row">
+            <td class="c">
+              <span class="lbl">NÚMERO DA NFS-e</span>
+              <span class="val">{{NUMERO_NFSE}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">COMPETÊNCIA DA NFS-e</span>
+              <span class="val">{{COMPETENCIA}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">DATA E HORA DA EMISSÃO DA NFS-e</span>
+              <span class="val">{{DATA_HORA_EMISSAO}}</span>
+            </td>
+          </tr>
+          <tr class="ident-row">
+            <td class="c">
+              <span class="lbl">NÚMERO DA DPS</span>
+              <span class="val">{{NUMERO_DPS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">SÉRIE DA DPS</span>
+              <span class="val">{{SERIE_DPS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">DATA E HORA DA EMISSÃO DA DPS</span>
+              <span class="val">{{DATA_HORA_EMISSAO_DPS}}</span>
+            </td>
+          </tr>
+          <tr class="ident-row">
+            <td class="c bg-cinza">
+              <span class="lbl">EMITENTE DA NFS-e</span>
+              <span class="val"><strong>{{EMITENTE_NFSE}}</strong></span>
+            </td>
+            <td class="c">
+              <span class="lbl">SITUAÇÃO DA NFS-e</span>
+              <span class="val">{{SITUACAO_NFSE}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">FINALIDADE</span>
+              <span class="val">{{FINALIDADE}}</span>
+            </td>
+          </tr>
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Prestador / Fornecedor</td>
+            <td class="c">
+              <span class="lbl">CNPJ / CPF / NIF</span>
+              <span class="val">{{PREST_CNPJ}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Indicador Municipal (Inscrição)</span>
+              <span class="val">{{PREST_IM}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Telefone</span>
+              <span class="val">{{PREST_FONE}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Nome / Nome Empresarial</span>
+              <span class="val">{{PREST_RAZAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Município / Sigla UF</span>
+              <span class="val">{{MUNICIPIO_EMITENTE}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Código IBGE / CEP</span>
+              <span class="val">{{PREST_CODIGO_CEP}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Endereço</span>
+              <span class="val">{{PREST_ENDERECO}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">E-mail</span>
+              <span class="val">{{PREST_EMAIL}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Simples Nacional na Data de Competência</span>
+              <span class="val">{{PREST_SIMPLES}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">Regime de Apuração Tributária pelo SN</span>
+              <span class="val">{{PREST_REGIME_SN}}</span>
+            </td>
+          </tr>
+
+          <!-- TOMADOR:BEGIN_IDENTIFIED -->
+          <tr class="sec-title">
+            <td class="sec-title-label">Tomador / Adquirente</td>
+            <td class="c">
+              <span class="lbl">CNPJ / CPF / NIF</span>
+              <span class="val">{{TOMA_CNPJ}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Indicador Municipal (Inscrição)</span>
+              <span class="val">{{TOMA_IM}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Telefone</span>
+              <span class="val">{{TOMA_FONE}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Nome / Nome Empresarial</span>
+              <span class="val">{{TOMA_RAZAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Município / Sigla UF</span>
+              <span class="val">{{TOMA_CMUN}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Código IBGE / CEP</span>
+              <span class="val">{{TOMA_CODIGO_CEP}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Endereço</span>
+              <span class="val">{{TOMA_ENDERECO}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">E-mail</span>
+              <span class="val">{{TOMA_EMAIL}}</span>
+            </td>
+          </tr>
+          <!-- TOMADOR:END_IDENTIFIED -->
+          <!-- TOMADOR:BEGIN_NOT_IDENTIFIED -->
+          <tr><td colspan="4" class="supr">TOMADOR/ADQUIRENTE DA OPERAÇÃO NÃO IDENTIFICADO NA NFS-e</td></tr>
+          <!-- TOMADOR:END_NOT_IDENTIFIED -->
+
+          <!-- DESTINATARIO:BEGIN_IDENTIFIED -->
+          <tr class="sec-title">
+            <td class="sec-title-label">Destinatário da Operação</td>
+            <td class="c">
+              <span class="lbl">CNPJ / CPF / NIF</span>
+              <span class="val">{{DEST_CNPJ}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Telefone</span>
+              <span class="val">{{DEST_FONE}}</span>
+            </td>
+            <td class="c"></td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Nome / Nome Empresarial</span>
+              <span class="val">{{DEST_RAZAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Município / Sigla UF</span>
+              <span class="val">{{DEST_CMUN}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Código IBGE / CEP</span>
+              <span class="val">{{DEST_CODIGO_CEP}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Endereço</span>
+              <span class="val">{{DEST_ENDERECO}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">E-mail</span>
+              <span class="val">{{DEST_EMAIL}}</span>
+            </td>
+          </tr>
+          <!-- DESTINATARIO:END_IDENTIFIED -->
+          <!-- DESTINATARIO:BEGIN_SAME_AS_TOMADOR -->
+          <tr><td colspan="4" class="supr">O DESTINATÁRIO É O PRÓPRIO TOMADOR/ADQUIRENTE DA OPERAÇÃO</td></tr>
+          <!-- DESTINATARIO:END_SAME_AS_TOMADOR -->
+          <!-- DESTINATARIO:BEGIN_NOT_IDENTIFIED -->
+          <tr><td colspan="4" class="supr">DESTINATÁRIO DA OPERAÇÃO NÃO IDENTIFICADO NA NFS-e</td></tr>
+          <!-- DESTINATARIO:END_NOT_IDENTIFIED -->
+
+          <!-- INTERMEDIARIO:BEGIN_IDENTIFIED -->
+          <tr class="sec-title">
+            <td class="sec-title-label">Intermediário da Operação</td>
+            <td class="c">
+              <span class="lbl">CNPJ / CPF / NIF</span>
+              <span class="val">{{INTER_CNPJ}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Indicador Municipal (Inscrição)</span>
+              <span class="val">{{INTER_IM}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Telefone</span>
+              <span class="val">{{INTER_FONE}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Nome / Nome Empresarial</span>
+              <span class="val">{{INTER_RAZAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Município / Sigla UF</span>
+              <span class="val">{{INTER_CMUN}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Código IBGE / CEP</span>
+              <span class="val">{{INTER_CODIGO_CEP}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c" colspan="2">
+              <span class="lbl">Endereço</span>
+              <span class="val">{{INTER_ENDERECO}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">E-mail</span>
+              <span class="val">{{INTER_EMAIL}}</span>
+            </td>
+          </tr>
+          <!-- INTERMEDIARIO:END_IDENTIFIED -->
+          <!-- INTERMEDIARIO:BEGIN_NOT_IDENTIFIED -->
+          <tr><td colspan="4" class="supr">INTERMEDIÁRIO DA OPERAÇÃO NÃO IDENTIFICADO NA NFS-e</td></tr>
+          <!-- INTERMEDIARIO:END_NOT_IDENTIFIED -->
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Serviço Prestado</td>
+            <td class="c">
+              <span class="lbl">Código de Tributação Nacional/Municipal</span>
+              <span class="val">{{SERV_CODIGOS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Código da NBS</span>
+              <span class="val">{{SERV_NBS_FORMATADO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Local da Prestação / Sigla UF / País</span>
+              <span class="val">{{SERV_LOCAL_COMPLETO}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c desc-tributacao" colspan="4"><span class="val wrap">{{SERV_DESCRICAO_TRIBUTACAO}}</span></td>
+          </tr>
+          <tr>
+            <td class="c desc-servico" colspan="4">
+              <span class="lbl">Descrição do Serviço</span>
+              <span class="val wrap">{{SERV_DESC_HTML}}</span>
+            </td>
+          </tr>
+
+          <!-- ISS:BEGIN_SUBJECT -->
+          <tr class="sec-title">
+            <td class="sec-title-label">Tributação Municipal (ISSQN)</td>
+            <td class="c">
+              <span class="lbl">Tipo de Tributação do ISSQN</span>
+              <span class="val">{{ISS_TRIBUTACAO}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">Município / Sigla UF / País de Incidência do ISSQN</span>
+              <span class="val">{{ISS_MUN_INC_COMPLETO}}</span>
+            </td>
+          </tr>
+          <!-- ISS_OPTIONAL_1:BEGIN -->
+          <tr>
+            <td class="c">
+              <span class="lbl">Regime Especial de Tributação ISSQN</span>
+              <span class="val">{{ISS_REGIME}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Tipo de Imunidade ISSQN</span>
+              <span class="val">{{ISS_OPERACAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Suspensão da Exigibilidade ISSQN</span>
+              <span class="val">{{ISS_SUSPENSAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Número Processo Suspensão</span>
+              <span class="val">{{ISS_PROCESSO}}</span>
+            </td>
+          </tr>
+          <!-- ISS_OPTIONAL_1:END -->
+          <!-- ISS_OPTIONAL_2:BEGIN -->
+          <tr>
+            <td class="c">
+              <span class="lbl">Benefício Municipal</span>
+              <span class="val">{{ISS_BENEFICIO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Cálculo do BM</span>
+              <span class="val">{{ISS_CALCULO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Total Deduções/Reduções</span>
+              <span class="val">{{ISS_DEDUCOES}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Desconto Incondicionado</span>
+              <span class="val">{{ISS_DESC_INCOND}}</span>
+            </td>
+          </tr>
+          <!-- ISS_OPTIONAL_2:END -->
+          <tr>
+            <td class="c">
+              <span class="lbl">BC ISSQN</span>
+              <span class="val">{{ISS_BC}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Alíquota Aplicada</span>
+              <span class="val">{{ISS_ALIQ}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Retenção do ISSQN</span>
+              <span class="val">{{ISS_RETENCAO}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">ISSQN Apurado</span>
+              <span class="val">{{ISS_APURADO}}</span>
+            </td>
+          </tr>
+          <!-- ISS:END_SUBJECT -->
+          <!-- ISS:BEGIN_NOT_SUBJECT -->
+          <tr>
+            <td class="iss-nao-sujeita" colspan="4">TRIBUTAÇÃO MUNICIPAL (ISSQN) - OPERAÇÃO NÃO SUJEITA AO ISSQN</td>
+          </tr>
+          <!-- ISS:END_NOT_SUBJECT -->
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Tributação Federal (Exceto CBS)</td>
+            <td class="c">
+              <span class="lbl">IRRF</span>
+              <span class="val">{{FED_IRRF}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Contribuição Previdenciária - Retida</span>
+              <span class="val">{{FED_CP}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Contribuições Sociais - Retidas</span>
+              <span class="val">{{FED_CSLL}}</span>
+            </td>
+          </tr>
+          <!-- PISCOFINS:BEGIN -->
+          <tr>
+            <td class="c">
+              <span class="lbl">PIS - Débito Apuração Própria</span>
+              <span class="val">{{FED_PIS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">COFINS - Débito Apuração Própria</span>
+              <span class="val">{{FED_COFINS}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">Descrição Contrib. Sociais - Retidas</span>
+              <span class="val">{{FED_RET_PISCOFINSCSLL}}</span>
+            </td>
+          </tr>
+          <!-- PISCOFINS:END -->
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Tributação IBS/CBS</td>
+            <td class="c">
+              <span class="lbl">CST / cClassTrib</span>
+              <span class="val">{{IBSCBS_CST_CLASS}}</span>
+            </td>
+            <td class="c" colspan="2">
+              <span class="lbl">Indicador de Operação / Código IBGE Incidência / Município Incidência / Sigla UF</span>
+              <span class="val">{{IBSCBS_INCIDENCIA}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c">
+              <span class="lbl">Exclusões e Reduções da Base de Cálculo</span>
+              <span class="val">{{IBSCBS_EXCLUSOES}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Base de Cálculo Após Exclusões e Reduções</span>
+              <span class="val">{{IBSCBS_BC}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Red. Alíquota IBS / Red. Alíquota CBS</span>
+              <span class="val">{{IBSCBS_REDUCOES}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Alíquota - IBS UF / IBS Mun</span>
+              <span class="val">{{IBSCBS_ALIQUOTAS_IBS}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c">
+              <span class="lbl">Alíq. Efetiva Municipal - IBS</span>
+              <span class="val">{{IBSCBS_ALIQ_EFET_MUN}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Valor Apurado Municipal - IBS</span>
+              <span class="val">{{IBSCBS_VALOR_MUN}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Alíq. Efetiva Estadual - IBS</span>
+              <span class="val">{{IBSCBS_ALIQ_EFET_UF}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Valor Apurado Estadual - IBS</span>
+              <span class="val">{{IBSCBS_VALOR_UF}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c">
+              <span class="lbl">Valor Total Apurado - IBS</span>
+              <span class="val">{{IBSCBS_TOTAL_IBS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Alíquota - CBS</span>
+              <span class="val">{{IBSCBS_ALIQ_CBS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Alíquota Efetiva - CBS</span>
+              <span class="val">{{IBSCBS_ALIQ_EFET_CBS}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Valor Total Apurado - CBS</span>
+              <span class="val">{{IBSCBS_TOTAL_CBS}}</span>
+            </td>
+          </tr>
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Valor Total da NFS-e</td>
+            <td class="c">
+              <span class="lbl">Valor da Operação / Serviço</span>
+              <span class="val"><strong>{{VALOR_SERVICO}}</strong></span>
+            </td>
+            <td class="c">
+              <span class="lbl">Desconto Incondicionado</span>
+              <span class="val">{{DESC_INCOND}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Desconto Condicionado</span>
+              <span class="val">{{DESC_COND}}</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="c">
+              <span class="lbl">Total das Retenções (ISSQN / Federais)</span>
+              <span class="val">{{TOTAL_RETENCOES}}</span>
+            </td>
+            <td class="c">
+              <span class="lbl">Valor Líquido da NFS-e</span>
+              <span class="val"><strong>{{VALOR_LIQUIDO}}</strong></span>
+            </td>
+            <td class="c">
+              <span class="lbl">Total do IBS/CBS</span>
+              <span class="val">{{IBSCBS_TOTAL}}</span>
+            </td>
+            <td class="c bg-cinza">
+              <span class="lbl">Valor Líquido da NFS-e + IBS/CBS</span>
+              <span class="val"><strong>{{IBSCBS_VALOR_TOTAL}}</strong></span>
+            </td>
+          </tr>
+
+          <tr class="sec-title">
+            <td class="sec-title-label">Informações Complementares</td>
+            <td colspan="3"></td>
+          </tr>
+          <tr>
+            <td class="c info-compl" colspan="4"><span class="val wrap">{{INF_COMPLEMENTARES}}</span></td>
+          </tr>
         </table>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- PRESTADOR -->
-      <div class="section">
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE_HEADER}}; color: black; font-weight: bold">
-                  EMITENTE DA NFS-e
-                </span>
-                <br />
-                {{PREST_SERV}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  CNPJ / CPF / NIF
-                </span>
-                <br />
-                {{PREST_CNPJ}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Inscrição Municipal
-                </span>
-                <br />
-                {{PREST_IM}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Telefone</span>
-                <br />
-                {{PREST_FONE}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Nome / Nome Empresarial
-                </span>
-                <br />
-                {{PREST_RAZAO}}
-              </td>
-              <td style="vertical-align: top; width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">E-mail</span>
-                <br />
-                {{PREST_EMAIL}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Endereço</span>
-                <br />
-                {{PREST_ENDERECO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Município</span>
-                <br />
-                {{PREST_MUNICIPIO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">CEP</span>
-                <br />
-                {{PREST_CEP}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Simples Nacional na Data de Competência
-                </span>
-                <br />
-                {{PREST_SIMPLES}}
-              </td>
-              <td style="vertical-align: top; width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Regime de Apuração Tributária pelo SN
-                </span>
-                <br />
-                {{PREST_REGIME_SN}}
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <!-- ======================= -->
-      <!-- TOMADOR (CONDICIONAL)   -->
-      <!-- ======================= -->
-      <!-- TOMADOR:BEGIN_NOT_IDENTIFIED -->
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <div class="section" style="border-bottom: none; text-align: center; font-size: 14px; font-weight: bold">
-        <span>TOMADOR DO SERVIÇO NÃO IDENTIFICADO NA NFS-e</span>
-      </div>
-      <!-- TOMADOR:END_NOT_IDENTIFIED -->
-      <!-- TOMADOR:BEGIN_IDENTIFIED -->
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <div class="section">
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE_HEADER}}; color: black; font-weight: bold">
-                  TOMADOR DO SERVIÇO
-                </span>
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  CNPJ / CPF / NIF
-                </span>
-                <br />
-                {{TOMA_CNPJ}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Inscrição Municipal
-                </span>
-                <br />
-                {{TOMA_IM}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Telefone</span>
-                <br />
-                {{TOMA_FONE}}
-              </td>
-            </tr>
-          </table>
-
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Nome / Nome Empresarial</span>
-                <br />
-                {{TOMA_RAZAO}}
-              </td>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">E-mail</span>
-                <br />
-                {{TOMA_EMAIL}}
-              </td>
-            </tr>
-          </table>
-
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Endereço</span>
-                <br />
-                {{TOMA_ENDERECO}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Município</span>
-                <br />
-                {{TOMA_CMUN}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">CEP</span>
-                <br />
-                {{TOMA_CEP}}
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <!-- TOMADOR:END_IDENTIFIED -->
-      <!-- ============================ -->
-      <!-- INTERMEDIÁRIO (CONDICIONAL)  -->
-      <!-- ============================ -->
-      <!-- INTERMEDIARIO:BEGIN_NOT_IDENTIFIED -->
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <div class="section" style="border-bottom: none; text-align: center; font-size: 14px; font-weight: bold">
-        <span>INTERMEDIÁRIO DO SERVIÇO NÃO IDENTIFICADO NA NFS-e</span>
-      </div>
-      <!-- INTERMEDIARIO:END_NOT_IDENTIFIED -->
-      <!-- INTERMEDIARIO:BEGIN_IDENTIFIED -->
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <div class="section">
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE_HEADER}}; font-weight: bold">
-                  INTERMEDIÁRIO DO SERVIÇO
-                </span>
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">CNPJ / CPF / NIF</span>
-                <br />
-                {{INTER_CNPJ}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Inscrição Municipal</span>
-                <br />
-                {{INTER_IM}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Telefone</span>
-                <br />
-                {{INTER_FONE}}
-              </td>
-            </tr>
-          </table>
-
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Nome / Nome Empresarial</span>
-                <br />
-                {{INTER_RAZAO}}
-              </td>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">E-mail</span>
-                <br />
-                {{INTER_EMAIL}}
-              </td>
-            </tr>
-          </table>
-
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="width: 50%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Endereço</span>
-                <br />
-                {{INTER_ENDERECO}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">Município</span>
-                <br />
-                {{INTER_CMUN}}
-              </td>
-              <td style="width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; font-weight: bold">CEP</span>
-                <br />
-                {{INTER_CEP}}
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <!-- INTERMEDIARIO:END_IDENTIFIED -->
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- SERVIÇO -->
-      <div class="section" style="border-bottom: none; height: 310px; max-height: 310px">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          Serviço Prestado
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Código de Tributação Nacional
-                </span>
-                <br />
-                {{SERV_CTRIBNAC}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Código de Tributação Municipal
-                </span>
-                <br />
-                {{SERV_CTRIBMUN}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Local da Prestação
-                </span>
-                <br />
-                {{SERV_LOCAL}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  País da Prestação
-                </span>
-                <br />
-                {{SERV_PAIS}}
-              </td>
-            </tr>
-          </table>
-          <div class="mt-1" style="margin-top: 5px; width: 100%">
-            <div style="width: 90%">
-              <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                Descrição do Serviço
-              </span>
-              <br />
-              {{SERV_DESC_HTML}}
-            </div>
-          </div>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- TRIBUTAÇÃO MUNICIPAL -->
-      <div class="section">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          TRIBUTAÇÃO MUNICIPAL
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Tributação do ISSQN
-                </span>
-                <br />
-                {{ISS_TRIBUTACAO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  País Resultado da Prestação do Serviço
-                </span>
-                <br />
-                {{ISS_PAIS}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Município de Incidência do ISSQN
-                </span>
-                <br />
-                {{ISS_MUN_INC}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Regime Especial de Tributação
-                </span>
-                <br />
-                {{ISS_REGIME}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Tipo de Imunidade
-                </span>
-                <br />
-                {{ISS_OPERACAO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Suspensão da Exigibilidade do ISSQN
-                </span>
-                <br />
-                {{ISS_SUSPENSAO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Número Processo Suspensão
-                </span>
-                <br />
-                {{ISS_PROCESSO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Benefício Municipal
-                </span>
-                <br />
-                {{ISS_BENEFICIO}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Valor do Serviço
-                </span>
-                <br />
-                {{VALOR_SERVICO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Desconto Incondicionado
-                </span>
-                <br />
-                {{ISS_DESC_INCOND}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Total Deduções/Reduções
-                </span>
-                <br />
-                {{ISS_DEDUCOES}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Cálculo do BM
-                </span>
-                <br />
-                {{ISS_CALCULO}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">BC ISSQN</span>
-                <br />
-                {{ISS_BC}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Alíquota Aplicada
-                </span>
-                <br />
-                {{ISS_ALIQ}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Retenção do ISSQN
-                </span>
-                <br />
-                {{ISS_RETENCAO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  ISSQN Apurado
-                </span>
-                <br />
-                {{ISS_APURADO}}
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- TRIBUTAÇÃO FEDERAL -->
-      <div class="section">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          TRIBUTAÇÃO FEDERAL
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">IRRF</span>
-                <br />
-                {{FED_IRRF}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Contribuição Previdenciária - Retida
-                </span>
-                <br />
-                {{FED_CP}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Contribuições Sociais - Retidas
-                </span>
-                <br />
-                {{FED_CSLL}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Descrição Contrib. Sociais - Retidas
-                </span>
-                <br />
-                {{FED_RET_PISCOFINSCSLL}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  PIS - Debito Apuração Própria
-                </span>
-                <br />
-                {{FED_PIS}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  COFINS - Debito Apuração Própria
-                </span>
-                <br />
-                {{FED_COFINS}}
-              </td>
-              <td style="vertical-align: top; width: 25%"></td>
-              <td style="vertical-align: top; width: 25%">
-                <!--<span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Total Tributação Federal
-                </span>
-                <br />
-                {{FED_TOTAL}}-->
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- VALOR TOTAL DA NFS-E -->
-      <div class="section">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          VALOR TOTAL DA NFS-E
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Valor do Serviço
-                </span>
-                <br />
-                {{VALOR_SERVICO}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Desconto Condicionado
-                </span>
-                <br />
-                {{DESC_COND}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Desconto Incondicionado
-                </span>
-                <br />
-                {{DESC_INCOND}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  ISSQN Retido
-                </span>
-                <br />
-                {{ISS_RETIDO}}
-              </td>
-            </tr>
-          </table>
-          <table style="width: 100%; border-collapse: collapse; margin-top: 5px">
-            <tr>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Total das Retenções Federais
-                </span>
-                <br />
-                {{FED_RETIDOS}}
-              </td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  PIS/COFINS - Débito Apur. Própria
-                </span>
-                <br />
-                {{PISCOFINS_DEB}}
-              </td>
-              <td style="vertical-align: top; width: 25%"></td>
-              <td style="vertical-align: top; width: 25%">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  Valor Líquido da NFS-e
-                </span>
-                <br />
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">
-                  {{VALOR_LIQUIDO}}
-                </span>
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- TOTAIS APROXIMADOS DOS TRIBUTOS -->
-      <div class="section">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          TOTAIS APROXIMADOS DOS TRIBUTOS
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <table style="width: 100%; border-collapse: collapse">
-            <tr style="text-align: center">
-              <td style="vertical-align: top">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Federais</span>
-                <br />
-                {{TOT_FED}}
-              </td>
-              <td style="vertical-align: top">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Estaduais</span>
-                <br />
-                {{TOT_EST}}
-              </td>
-              <td style="vertical-align: top">
-                <span class="label" style="font-size: {{FONT_SIZE}}; color: black; font-weight: bold">Municipais</span>
-                <br />
-                {{TOT_MUN}}
-              </td>
-            </tr>
-          </table>
-        </div>
-      </div>
-      <div style="border-top: 1px solid #000; margin: 0 5px"></div>
-      <!-- INFORMAÇÕES COMPLEMENTARES -->
-      <div class="section" style="border-bottom: none; height: 110px; max-height: 110px">
-        <div
-          class="section-title"
-          style="padding: 4px 6px; font-size: {{FONT_SIZE_HEADER}}; text-transform: uppercase; font-weight: bold"
-        >
-          INFORMAÇÕES COMPLEMENTARES
-        </div>
-        <div class="section-content" style="padding: 1px 6px 6px 6px">
-          <div>{{INF_COMPLEMENTARES}}</div>
-        </div>
+        <table class="canhoto">
+          <tr>
+            <td style="width: 25%"><span class="lbl">Data Cientificação:</span></td>
+            <td style="width: 25%"><span class="lbl">Identificação e Assinatura</span></td>
+            <td style="width: 50%">
+              <span class="lbl">Nº NFS-e / Chave NFS-e</span>
+              <span class="val wrap">{{NUMERO_NFSE}} / {{CHAVE_ACESSO}}</span>
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
   </body>

--- a/src/Danfe/Danfe.csproj
+++ b/src/Danfe/Danfe.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
     <!-- Multi-target so the same package can be used by legacy .NET Framework 4.8 and .NET (Core) apps -->
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>false</ImplicitUsings>
@@ -30,8 +30,16 @@
 
   <!-- NuGet packages (replaces packages.config + HintPath references) -->
   <ItemGroup>
-    <PackageReference Include="NReco.PdfGenerator" Version="1.2.1" />
+    <PackageReference Include="DinkToPdf" Version="1.0.8" />
     <PackageReference Include="QRCoder" Version="1.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\libs\libwkhtmltox.so"
+          Link="libwkhtmltox.so"
+          CopyToOutputDirectory="PreserveNewest"
+          Pack="true"
+          PackagePath="runtimes/linux-x64/native" />
   </ItemGroup>
 
   <!-- net48-only framework references that do NOT exist on .NET Standard -->
@@ -58,21 +66,15 @@
 
 <ItemGroup>
     <!-- Para projetos SDK/PackageReference -->
-    <None Include="buildTransitive\Direction.NFSe.Danfe.targets"
-            Pack="true"
-            PackagePath="buildTransitive\Direction.NFSe.Danfe.targets" />
+    <None Include="buildTransitive\Direction.NFSe.Danfe.targets" Pack="true" PackagePath="buildTransitive\Direction.NFSe.Danfe.targets" />
 
     <!-- Para projetos .NET Framework clássicos (non-SDK) -->
-    <None Include="buildTransitive\Direction.NFSe.Danfe.targets"
-            Pack="true"
-            PackagePath="build\Direction.NFSe.Danfe.targets" />
+    <None Include="buildTransitive\Direction.NFSe.Danfe.targets" Pack="true" PackagePath="build\Direction.NFSe.Danfe.targets" />
 </ItemGroup>
 
 
     <ItemGroup>
-  <None Include="Assets\**\*"
-        Pack="true"
-        PackagePath="contentFiles\any\any\Direction.NFSe.Danfe\Assets\">
+  <None Include="Assets\**\*" Pack="true" PackagePath="contentFiles\any\any\Direction.NFSe.Danfe\Assets\">
     <PackageCopyToOutput>true</PackageCopyToOutput>
   </None>
 </ItemGroup>

--- a/src/Danfe/Internal/Helper.cs
+++ b/src/Danfe/Internal/Helper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -50,8 +51,8 @@ namespace Direction.NFSe.Danfe
         public static string BuildDescricaoServicoHtml(string? desc)
         {
             if (string.IsNullOrWhiteSpace(desc)) return "-";
-            // encode e depois quebra linha em <br/>
-            var encoded = HtmlEncode(desc!);
+            // A NT 008 limita o campo a 1.300 caracteres, com reticências.
+            var encoded = HtmlEncode(desc.Limit(1300));
             return encoded.Replace("\r\n", "<br/>").Replace("\n", "<br/>");
         }
 
@@ -82,6 +83,9 @@ namespace Direction.NFSe.Danfe
 
                 if (!string.IsNullOrEmpty(serv.infoCompl.xInfComp))
                     AppendWithSeparator(sb, $"<b>Inf Cont:</b> {serv.infoCompl.xInfComp}");
+
+                if (!string.IsNullOrWhiteSpace(serv.infoCompl.docRef))
+                    AppendWithSeparator(sb, $"<b>Doc Ref:</b> {serv.infoCompl.docRef}");
             }
 
             if (serv.cServ.cNBS != 0)
@@ -90,6 +94,63 @@ namespace Direction.NFSe.Danfe
             }
 
             return sb.Length == 0 ? "-" : sb.ToString();
+        }
+
+        public static string BuildInfComplementares(InfNFSe inf, CultureInfo culture)
+        {
+            var items = new List<string>();
+            var infDps = inf.DPS?.InfDPS;
+            var serv = infDps?.serv;
+
+            AppendComplementary(items, "Inf. Cont.:", serv?.infoCompl?.xInfComp);
+            AppendComplementary(items, "NFS-e Subst.:", infDps?.subst?.chSubstda);
+            AppendComplementary(items, "Doc. Ref.:", serv?.infoCompl?.docRef);
+            AppendComplementary(items, "Cod. Obra:", serv?.obra?.cObra);
+            AppendComplementary(items, "Insc. Imob.:", infDps?.IBSCBS?.imovel?.inscImobFisc ?? serv?.obra?.inscImobFisc);
+            AppendComplementary(items, "Cod. Evt.:", serv?.atvEvento?.idAtvEvt);
+            AppendComplementary(items, "Doc. Tec.:", serv?.infoCompl?.idDocTec);
+            AppendComplementary(items, "Núm. Ped.:", serv?.infoCompl?.xPed);
+
+            var itensPedido = serv?.infoCompl?.gItemPed?.xItemPed;
+            if (itensPedido is { Count: > 0 })
+                AppendComplementary(items, "Item Ped.:", string.Join(", ", itensPedido));
+
+            AppendComplementary(items, "Inf. A. T. Mun.:", inf.valores?.xOutInf);
+
+            // Reserva a linha obrigatória dos totais; somente o conteúdo anterior é truncado.
+            var complementares = string.Join(" | ", items).Limit(1997);
+            var totais = BuildTotaisAproximados(infDps?.valores?.trib?.totTrib, culture);
+            return string.IsNullOrEmpty(complementares)
+                ? totais
+                : $"{HtmlEncode(complementares)}<br/>{totais}";
+        }
+
+        private static void AppendComplementary(List<string> items, string label, string? value)
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+                items.Add($"{label} {value!.Trim()}");
+        }
+
+        private static string BuildTotaisAproximados(TotTrib? totais, CultureInfo culture)
+        {
+            string federal = "-";
+            string estadual = "-";
+            string municipal = "-";
+
+            if (totais?.vTotTrib != null)
+            {
+                federal = totais.vTotTrib.vTotTribFed.ToString("C", culture);
+                estadual = totais.vTotTrib.vTotTribEst.ToString("C", culture);
+                municipal = totais.vTotTrib.vTotTribMun.ToString("C", culture);
+            }
+            else if (totais?.pTotTrib != null)
+            {
+                federal = $"{totais.pTotTrib.pTotTribFed.ToString("N2", culture)}%";
+                estadual = $"{totais.pTotTrib.pTotTribEst.ToString("N2", culture)}%";
+                municipal = $"{totais.pTotTrib.pTotTribMun.ToString("N2", culture)}%";
+            }
+
+            return $"Totais Aproximados dos Tributos cfe. Lei nº 12.741/2012: Federais: {federal}; Estaduais: {estadual}; Municipais: {municipal};";
         }
 
         public static DateTime? TryParseDate(string? value)
@@ -145,6 +206,21 @@ namespace Direction.NFSe.Danfe
             return fone!;
         }
 
+        public static string FormatTaxIdentifier(string? cnpj, string? cpf, string? nif)
+        {
+            if (!string.IsNullOrWhiteSpace(cnpj)) return FormatCnpj(cnpj);
+            if (!string.IsNullOrWhiteSpace(cpf)) return FormatCpf(cpf);
+            return NullToDash(nif);
+        }
+
+        public static string FormatNbs(int nbs)
+        {
+            if (nbs == 0) return "-";
+
+            var value = nbs.ToString("D9", CultureInfo.InvariantCulture);
+            return Regex.Replace(value, @"^(\d)(\d{4})(\d{2})(\d{2})$", "$1.$2.$3.$4");
+        }
+
         public static string OnlyDigits(string s)
         {
             var sb = new StringBuilder(s?.Length ?? 0);
@@ -173,7 +249,8 @@ namespace Direction.NFSe.Danfe
             var corte = texto!.Substring(0, maxChars - 3); // reserva espaço para "..."
             var ultimoEspaco = corte.LastIndexOf(' ');
 
-            if (ultimoEspaco > 0)
+            // Evita descartar quase todo o conteúdo quando há uma palavra longa sem espaços.
+            if (ultimoEspaco >= corte.Length - 40)
                 corte = corte.Substring(0, ultimoEspaco);
 
             return corte + "...";
@@ -194,7 +271,16 @@ namespace Direction.NFSe.Danfe
             return Regex.Replace(html, pattern, "", RegexOptions.Singleline);
         }
 
-        public static string ApplyConditionalSections(string html, bool hasTomador, bool hasIntermediario)
+        public static string ApplyConditionalSections(
+            string html,
+            bool hasTomador,
+            bool hasIntermediario,
+            bool hasDestinatario,
+            bool destinatarioIsTomador,
+            bool showPisCofins,
+            bool issSubject,
+            bool showIssOptionalRow1,
+            bool showIssOptionalRow2)
         {
             // TOMADOR
             if (hasTomador)
@@ -215,6 +301,37 @@ namespace Direction.NFSe.Danfe
             {
                 html = RemoveBlock(html, "<!-- INTERMEDIARIO:BEGIN_IDENTIFIED -->", "<!-- INTERMEDIARIO:END_IDENTIFIED -->");
             }
+
+            // DESTINATARIO
+            if (hasDestinatario)
+            {
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_SAME_AS_TOMADOR -->", "<!-- DESTINATARIO:END_SAME_AS_TOMADOR -->");
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_NOT_IDENTIFIED -->", "<!-- DESTINATARIO:END_NOT_IDENTIFIED -->");
+            }
+            else if (destinatarioIsTomador)
+            {
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_IDENTIFIED -->", "<!-- DESTINATARIO:END_IDENTIFIED -->");
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_NOT_IDENTIFIED -->", "<!-- DESTINATARIO:END_NOT_IDENTIFIED -->");
+            }
+            else
+            {
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_IDENTIFIED -->", "<!-- DESTINATARIO:END_IDENTIFIED -->");
+                html = RemoveBlock(html, "<!-- DESTINATARIO:BEGIN_SAME_AS_TOMADOR -->", "<!-- DESTINATARIO:END_SAME_AS_TOMADOR -->");
+            }
+
+            if (!showPisCofins)
+                html = RemoveBlock(html, "<!-- PISCOFINS:BEGIN -->", "<!-- PISCOFINS:END -->");
+
+            if (issSubject)
+                html = RemoveBlock(html, "<!-- ISS:BEGIN_NOT_SUBJECT -->", "<!-- ISS:END_NOT_SUBJECT -->");
+            else
+                html = RemoveBlock(html, "<!-- ISS:BEGIN_SUBJECT -->", "<!-- ISS:END_SUBJECT -->");
+
+            if (!showIssOptionalRow1)
+                html = RemoveBlock(html, "<!-- ISS_OPTIONAL_1:BEGIN -->", "<!-- ISS_OPTIONAL_1:END -->");
+
+            if (!showIssOptionalRow2)
+                html = RemoveBlock(html, "<!-- ISS_OPTIONAL_2:BEGIN -->", "<!-- ISS_OPTIONAL_2:END -->");
 
             return html;
         }

--- a/src/Danfe/Pdf/DanfePdfGenerator.cs
+++ b/src/Danfe/Pdf/DanfePdfGenerator.cs
@@ -1,20 +1,50 @@
-using NReco.PdfGenerator;
+using DinkToPdf;
+using DinkToPdf.Contracts;
 
 namespace Direction.NFSe.Danfe;
 
 public sealed class DanfePdfGenerator
 {
-    private readonly HtmlToPdfConverter _converter;
+    private static readonly IConverter _converter = new SynchronizedConverter(new PdfTools());
 
-    public DanfePdfGenerator(HtmlToPdfConverter? converter = null)
+    public byte[] Generate(string html)
     {
-        _converter = converter ?? new HtmlToPdfConverter
-        {
-            Size = PageSize.A4,
-            Orientation = PageOrientation.Portrait,
-            Margins = new PageMargins { Top = 1, Bottom = 0, Left = 0, Right = 0 }
-        };
+        return GenerateInternal(html);
     }
 
-    public byte[] Generate(string html) => _converter.GeneratePdf(html);
+    private static byte[] GenerateInternal(string html)
+    {
+        var document = new HtmlToPdfDocument
+        {
+            GlobalSettings =
+            {
+                PaperSize = PaperKind.A4,
+                Orientation = Orientation.Portrait,
+                Margins = new MarginSettings
+                {
+                    Top = 0,
+                    Bottom = 0,
+                    Left = 0,
+                    Right = 0
+                }
+            },
+            Objects =
+            {
+                new ObjectSettings
+                {
+                    HtmlContent = html,
+                    WebSettings =
+                    {
+                        DefaultEncoding = "utf-8",
+                        LoadImages = true,
+                        Background = true,
+                        EnableIntelligentShrinking = false,
+                        PrintMediaType = true
+                    }
+                }
+            }
+        };
+
+        return _converter.Convert(document);
+    }
 }

--- a/src/Danfe/Public/DanfeService.cs
+++ b/src/Danfe/Public/DanfeService.cs
@@ -4,16 +4,16 @@ using System.Xml.Serialization;
 
 namespace Direction.NFSe.Danfe;
 
-public sealed class DanfeService
+public sealed class DanfeService : IDanfeService
 {
     private readonly DanfeHtmlRenderer _renderer;
     private readonly DanfePdfGenerator _pdf;
 
-    public DanfeService(DanfeOptions? options = null, NReco.PdfGenerator.HtmlToPdfConverter? converter = null)
+    public DanfeService(DanfeOptions? options = null)
     {
         options ??= new DanfeOptions();
         _renderer = new DanfeHtmlRenderer(options);
-        _pdf = new DanfePdfGenerator(converter);
+        _pdf = new DanfePdfGenerator();
     }
 
     public DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada)
@@ -53,7 +53,7 @@ public sealed class DanfeService
         return Generate(nfse, environment, status);
     }
     [Obsolete("Use Generate(string, DanfeEnvironment, DanfeStatus).")]
-    public DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled)
     {
         using var sr = new StringReader(xml);
         var nfse = Deserialize(sr);
@@ -67,7 +67,7 @@ public sealed class DanfeService
         return Generate(nfse, environment, status);
     }
     [Obsolete("Use Generate(Stream, DanfeEnvironment, DanfeStatus).")]
-    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled = false)
+    public DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled)
     {
         using var sr = new StreamReader(xmlStream);
         var nfse = Deserialize(sr);

--- a/src/Danfe/Public/IDanfeService.cs
+++ b/src/Danfe/Public/IDanfeService.cs
@@ -1,0 +1,20 @@
+using System.IO;
+
+namespace Direction.NFSe.Danfe
+{
+    public interface IDanfeService
+    {
+        DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada);
+        DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada);
+        DanfeResult Generate(string xml, DanfeEnvironment environment, DanfeStatus status = DanfeStatus.Autorizada);
+
+        [System.Obsolete("Use Generate(NFSeSchema, DanfeEnvironment, DanfeStatus).")]
+        DanfeResult Generate(NFSeSchema nfse, DanfeEnvironment environment, bool isCancelled);
+
+        [System.Obsolete("Use Generate(Stream, DanfeEnvironment, DanfeStatus).")]
+        DanfeResult Generate(Stream xmlStream, DanfeEnvironment environment, bool isCancelled);
+
+        [System.Obsolete("Use Generate(string, DanfeEnvironment, DanfeStatus).")]
+        DanfeResult Generate(string xml, DanfeEnvironment environment, bool isCancelled);
+    }
+}

--- a/src/Danfe/Rendering/DanfeHtmlRenderer.cs
+++ b/src/Danfe/Rendering/DanfeHtmlRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -13,14 +14,15 @@ public sealed class DanfeHtmlRenderer
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
 
     private readonly string _templatePath;
+    private readonly string _basePath;
     private readonly DanfeOptions _options;
 
     public DanfeHtmlRenderer(DanfeOptions options)
     {
         _options = options ?? new DanfeOptions();
 
-        var basePath = _options.BasePath ?? AppContext.BaseDirectory;
-        _templatePath = _options.TemplatePath ?? Path.Combine(basePath, "Assets", "Templates", "Danfe.html");
+        _basePath = _options.BasePath ?? AppContext.BaseDirectory;
+        _templatePath = _options.TemplatePath ?? Path.Combine(_basePath, "Assets", "Templates", "Danfe.html");
     }
 
     public (string Html, IReadOnlyList<DanfeWarning> Warnings) RenderInternal(NFSeSchema nfse, DanfeEnvironment environment, DanfeStatus status)
@@ -104,16 +106,18 @@ public sealed class DanfeHtmlRenderer
         }
 
         // Município prestador
-        var cLocPrest = infDps.serv?.locPrest?.cLocPrestacao;
-        var municipioPrestador = cLocPrest != null ? MunicipiosIbge.GetMunicipio(cLocPrest) : null;
-        if (cLocPrest == null)
+        int? cLocPrest = infDps.serv?.locPrest?.cLocPrestacao;
+        var municipioPrestador = cLocPrest is > 0 ? MunicipiosIbge.GetMunicipio(cLocPrest.Value) : null;
+        if (cLocPrest is null or 0)
             warnings.FieldMissing("cLocPrestacao", "infNFSe.DPS.InfDPS.serv.locPrest.cLocPrestacao", "-");
         else if (municipioPrestador == null)
             warnings.MunicipioNotFound("infNFSe.DPS.InfDPS.serv.locPrest.cLocPrestacao");
 
         var cLocIncid = inf.cLocIncid;
-        var municpioISSQN = cLocIncid != null ? MunicipiosIbge.GetMunicipio(Int32.Parse(cLocIncid)) : null;
-        if (cLocPrest == null)
+        var municpioISSQN = int.TryParse(cLocIncid, out var codigoIncidencia)
+            ? MunicipiosIbge.GetMunicipio(codigoIncidencia)
+            : null;
+        if (string.IsNullOrWhiteSpace(cLocIncid))
             warnings.FieldMissing("cLocIncid", "infNFSe.cLocIncid", "-");
         else if (municpioISSQN == null)
             warnings.MunicipioNotFound("infNFSe.cLocIncid");
@@ -121,7 +125,7 @@ public sealed class DanfeHtmlRenderer
         var logoBase64 = GetLogoMunicipio(municipioPrestador);
 
         // Logo da nfse
-        var logoNfse = _options.LogoNFSePath != null ? Helper.GetLogo(_options.LogoNFSePath) : Helper.GetLogo(Path.Combine(AppContext.BaseDirectory, "Assets", "Logos", "nfse.png"));
+        var logoNfse = _options.LogoNFSePath != null ? Helper.GetLogo(_options.LogoNFSePath) : Helper.GetLogo(Path.Combine(_basePath, "Assets", "Logos", "nfse.png"));
 
         // Caminhos/valores auxiliares
         int? tpRetIssqn = infDps.valores?.trib?.tribMun?.tpRetISSQN;
@@ -139,6 +143,28 @@ public sealed class DanfeHtmlRenderer
         decimal? vCP = infDps.valores?.trib?.tribFed?.vRetCP;
         decimal? vCSLL = infDps.valores?.trib?.tribFed?.vRetCSLL;
 
+        var ibsCbsDps = infDps.IBSCBS;
+        var ibsCbs = inf.IBSCBS;
+        var valoresIbsCbs = ibsCbs?.valores;
+        var totaisIbsCbs = ibsCbs?.totCIBS;
+        var tribMun = infDps.valores?.trib?.tribMun;
+        var tpRetPisCofinsValue = infDps.valores?.trib?.tribFed?.piscofins?.tpRetPisCofins;
+
+        decimal? contribuicoesSociaisRetidas = vCSLL;
+        decimal? pisDebitoProprio = vPIS;
+        decimal? cofinsDebitoProprio = vCOFINS;
+        if (tpRetPisCofinsValue == 1)
+        {
+            contribuicoesSociaisRetidas = (vCSLL ?? 0m) + (vPIS ?? 0m) + (vCOFINS ?? 0m);
+            pisDebitoProprio = 0m;
+            cofinsDebitoProprio = 0m;
+        }
+
+        var exclusoesReducaoBase = CalculateIbsCbsExclusions(vDescIncond, valoresIbsCbs?.vCalcReeRepRes, vIssqn, vPIS, vCOFINS);
+        var totalIbsCbs = SumNullable(totaisIbsCbs?.gIBS?.vIBSTot, totaisIbsCbs?.gCBS?.vCBS);
+        var calculoBeneficioMunicipal = inf.valores?.vCalcBM ?? tribMun?.BM?.vRedBCBM;
+        var totalDeducoesReducoes = ResolveIssDeductions(infDps, inf, valoresIbsCbs);
+
         decimal? vTotTribFed = infDps.valores?.trib?.totTrib?.vTotTrib?.vTotTribFed;
         if (vTotTribFed == null || (vTotTribFed.HasValue && vTotTribFed.Value == 0M)) //nem sempre o objeto totalizador é informado no xml
             vTotTribFed = (vIRRF ?? 0M) + (vPIS ?? 0M) + (vCOFINS ?? 0M) + (vCP ?? 0M) + (vCSLL ?? 0M);
@@ -146,58 +172,26 @@ public sealed class DanfeHtmlRenderer
         decimal vTotalRetFed = (vIRRF ?? 0M) + (vCP ?? 0M) + (vCSLL ?? 0M);
         decimal vDebPisCofins = (vPIS ?? 0M) + (vCOFINS ?? 0M);
 
-        // Verifica se a NFSe está cancelada
-        var isCancelled = status == DanfeStatus.Cancelada;
-        string canceladaDiv = isCancelled
-            ? @"<div style=""
-              position:absolute;
-              top:50%;
-              left:50%;
-              display:inline-block;                 /* importante */
-              -webkit-transform: translate(-50%, -50%) rotate(-30deg);
-              transform: translate(-50%, -50%) rotate(-30deg);
-              -webkit-transform-origin: 50% 50%;
-              transform-origin: 50% 50%;
-              font-size:96px;
-              font-weight:800;
-              color: rgba(200,0,0,0.18);
-              border: 8px solid rgba(200,0,0,0.18);
-              padding: 20px 40px;
-              text-transform:uppercase;
-              z-index:9999;
-              pointer-events:none;
-              white-space:nowrap;"">
-                          CANCELADA
-              </div>"
-            : string.Empty;
-
-        // Verifica se a NFSe foi substituída e não cancelada
-        var isSubstituida = status == DanfeStatus.Substituida;
-        string substituidaDiv = isSubstituida
-            ? @"<div style=""
-              position:absolute;
-              top:50%;
-              left:50%;
-              display:inline-block;                 /* importante */
-              -webkit-transform: translate(-50%, -50%) rotate(-30deg);
-              transform: translate(-50%, -50%) rotate(-30deg);
-              -webkit-transform-origin: 50% 50%;
-              transform-origin: 50% 50%;
-              font-size:96px;
-              font-weight:800;
-              color: rgba(200,0,0,0.18);
-              border: 8px solid rgba(200,0,0,0.18);
-              padding: 20px 40px;
-              text-transform:uppercase;
-              z-index:9999;
-              pointer-events:none;
-              white-space:nowrap;"">
-                          SUBSTITUÍDA
-              </div>"
-            : string.Empty;
+        var canceladaDiv = status == DanfeStatus.Cancelada ? BuildWatermark("CANCELADA") : string.Empty;
+        var substituidaDiv = status == DanfeStatus.Substituida ? BuildWatermark("SUBSTITUÍDA") : string.Empty;
 
         bool hasTomador = infDps.toma != null;
         bool hasIntermediario = infDps.interm != null;
+        bool hasDestinatario = ibsCbsDps?.dest != null;
+        bool destinatarioIsTomador = !hasDestinatario && ibsCbsDps?.indDest == 0 && hasTomador;
+        bool showPisCofins = !competencia.HasValue || competencia.Value.Year <= 2026;
+        bool issSubject = tribMun?.tribISSQN != 4;
+        bool showIssOptionalRow1 = infDps.prest?.regTrib?.regEspTrib > 0 ||
+                                   tribMun?.tpImunidade.HasValue == true ||
+                                   tribMun?.exigSusp != null;
+        bool showIssOptionalRow2 = !string.IsNullOrWhiteSpace(inf.valores?.tpBM) ||
+                                   tribMun?.BM?.vRedBCBM.HasValue == true ||
+                                   inf.valores?.vCalcBM.HasValue == true ||
+                                   inf.valores?.vCalcDR.HasValue == true ||
+                                   infDps.valores?.vDedRed != null ||
+                                   valoresIbsCbs?.vDR.HasValue == true ||
+                                   valoresIbsCbs?.vCalcReeRepRes.HasValue == true ||
+                                   infDps.valores?.vDescCondIncond?.vDescIncond.HasValue == true;
 
         // Monta mapa de placeholders (agora com warnings)
         var map = new Dictionary<string, string>
@@ -219,6 +213,9 @@ public sealed class DanfeHtmlRenderer
             // Cabeçalho
             ["{{VALIDADE_JURIDICA}}"] = validade,
             ["{{CHAVE_ACESSO}}"] = DanfeFallback.OrDash(chaveAcesso, warnings, fieldName: "chaveAcesso", path: "infNFSe.Id"),
+            ["{{MUNICIPIO_EMITENTE}}"] = FormatMunicipioUf(inf.xLocEmi, inf.emit?.enderNac?.UF),
+            ["{{AMBIENTE_GERADOR}}"] = inf.ambGer > 0 ? inf.ambGer.ToString(CultureInfo.InvariantCulture) : "-",
+            ["{{TIPO_AMBIENTE}}"] = infDps.tpAmb > 0 ? infDps.tpAmb.ToString(CultureInfo.InvariantCulture) : "-",
 
             // QrCode
             ["{{QRCODE_SRC}}"] = imgQrCodeSrc,
@@ -230,16 +227,19 @@ public sealed class DanfeHtmlRenderer
             ["{{COMPETENCIA}}"] = competencia?.ToString("dd/MM/yyyy") ?? DanfeFallback.OrDash(null, warnings, "dCompet", "infNFSe.DPS.InfDPS.dCompet"),
             ["{{DATA_HORA_EMISSAO}}"] = dhEmissaoNfs?.ToString("dd/MM/yyyy HH:mm:ss") ?? DanfeFallback.OrDash(null, warnings, "dhProc", "infNFSe.dhProc"),
             ["{{DATA_HORA_EMISSAO_DPS}}"] = dhEmissaoDps?.ToString("dd/MM/yyyy HH:mm:ss") ?? DanfeFallback.OrDash(null, warnings, "dhEmi", "infNFSe.DPS.InfDPS.dhEmi"),
+            ["{{EMITENTE_NFSE}}"] = GetDescricaoEmitenteV2(infDps.tpEmit),
+            ["{{SITUACAO_NFSE}}"] = GetDescricaoSituacao(inf.cStat),
+            ["{{FINALIDADE}}"] = GetDescricaoFinalidade(ibsCbsDps?.finNFSe),
 
             // Prestador
             ["{{PREST_SERV}}"] = GetDescricaoEmitente(infDps.tpEmit),
-            ["{{PREST_CNPJ}}"] = !string.IsNullOrEmpty(infDps.prest?.CPF) ? DanfeFallback.OrDash(Helper.FormatCpf(infDps.prest?.CPF), warnings, fieldName: "CNPJ Prestador", path: "infNFSe.DPS.InfDPS.prest.CPF")
-                : DanfeFallback.OrDash(Helper.FormatCnpj(infDps.prest?.CNPJ), warnings, fieldName: "CNPJ Prestador", path: "infNFSe.DPS.InfDPS.prest.CNPJ"),
+            ["{{PREST_CNPJ}}"] = DanfeFallback.OrDash(Helper.FormatTaxIdentifier(infDps.prest?.CNPJ, infDps.prest?.CPF, infDps.prest?.NIF), warnings, fieldName: "CNPJ/CPF/NIF Prestador", path: "infNFSe.DPS.InfDPS.prest"),
             ["{{PREST_IM}}"] = DanfeFallback.OrDash(infDps.prest?.IM, warnings, "IM Prestador", "infNFSe.DPS.InfDPS.prest.IM"),
             ["{{PREST_RAZAO}}"] = DanfeFallback.OrDash(inf.emit?.xNome, warnings, "xNome Prestador", "infNFSe.emit.xNome"),
             ["{{PREST_ENDERECO}}"] = DanfeFallback.OrDash(Helper.BuildEndereco(inf.emit?.enderNac), warnings, "Endereço Prestador", "infNFSe.emit.enderNac"),
             ["{{PREST_MUNICIPIO}}"] = DanfeFallback.OrDash($"{inf.xLocEmi} - {inf.emit?.enderNac?.UF}", warnings, "Município/UF Prestador", "infNFSe.xLocEmi | infNFSe.emit.enderNac.UF"),
             ["{{PREST_CEP}}"] = DanfeFallback.OrDash(Helper.FormatCep(inf.emit?.enderNac?.CEP), warnings, "CEP Prestador", "infNFSe.emit.enderNac.CEP"),
+            ["{{PREST_CODIGO_CEP}}"] = FormatCodigoCep(inf.emit?.enderNac?.cMun, inf.emit?.enderNac?.CEP),
             ["{{PREST_FONE}}"] = DanfeFallback.OrDash(Helper.FormatTelefone(infDps.prest?.fone), warnings, "Fone Prestador", "infNFSe.DPS.InfDPS.prest.fone"),
             ["{{PREST_EMAIL}}"] = DanfeFallback.OrDash(infDps.prest?.email, warnings, "Email Prestador", "infNFSe.DPS.InfDPS.prest.email"),
             ["{{PREST_SIMPLES}}"] = GetDescricaoPrestadorSimples(infDps.prest?.regTrib?.opSimpNac),
@@ -254,6 +254,10 @@ public sealed class DanfeHtmlRenderer
             ["{{SERV_CTRIBMUN}}"] = DanfeFallback.OrDash(descricaoTributoMunicipal, warnings, "Descrição Tributo Municipal", "infNFSe.DPS.InfDPS.serv.cServ.cTribMun | infNFSe.xTribMun").Limit(80),
             ["{{SERV_NBS}}"] = DanfeFallback.OrDash(infDps.serv?.cServ?.cNBS.ToString(), warnings, "cNBS", "infNFSe.DPS.InfDPS.serv.cServ.cNBS"),
             ["{{SERV_DESC_HTML}}"] = Helper.BuildDescricaoServicoHtml(infDps.serv?.cServ?.xDescServ),
+            ["{{SERV_CODIGOS}}"] = $"{FormatTributacaoCode(cTribNac)} / {DanfeFallback.OrDash(cTribMun)}",
+            ["{{SERV_NBS_FORMATADO}}"] = Helper.FormatNbs(infDps.serv?.cServ?.cNBS ?? 0),
+            ["{{SERV_LOCAL_COMPLETO}}"] = JoinSlash(inf.xLocPrestacao ?? municipioPrestador?.Nome, municipioPrestador?.Uf, infDps.serv?.locPrest?.cPaisPrestacao),
+            ["{{SERV_DESCRICAO_TRIBUTACAO}}"] = DanfeFallback.OrDash(FirstNonEmpty(xTribMun, xTribNac).Limit(170), warnings, "Descricao da tributacao", "infNFSe.xTribMun | infNFSe.xTribNac"),
             ["{{SERV_LOCAL}}"] = DanfeFallback.OrDash(municipioPrestador?.NomeComUf, warnings, "Município Prestação", "MunicipiosIbge.GetMunicipio(cLocPrestacao).NomeComUf"),
             ["{{SERV_PAIS}}"] = DanfeFallback.OrDash(infDps.serv?.locPrest?.cPaisPrestacao, warnings, "País da Prestação", "infNFSe.DPS.InfDPS.serv.locPrest.cPaisPrestacao"),
 
@@ -263,13 +267,14 @@ public sealed class DanfeHtmlRenderer
             ["{{ISS_PAIS}}"] = DanfeFallback.OrDash(infDps.toma?.end?.endExt?.cPais, warnings, "País Resultado da Prestação do Serviço", "infNFSe.DPS.InfDPS.toma.end.endExt.cPais"),
             ["{{ISS_MUN_INC}}"] = DanfeFallback.OrDash(municpioISSQN?.NomeComUf, warnings, "Município Incidência", "MunicipiosIbge.GetMunicipio(cLocIncid).NomeComUf"),
             ["{{ISS_REGIME}}"] = GetDescricaoRegimeEspecial(infDps.prest?.regTrib?.regEspTrib),
+            ["{{ISS_MUN_INC_COMPLETO}}"] = JoinSlash(inf.xLocIncid ?? municpioISSQN?.Nome, municpioISSQN?.Uf, infDps.valores?.trib?.tribMun?.cPaisResult),
             ["{{ISS_OPERACAO}}"] = GetDescricaoTipoImunidade(infDps.valores?.trib?.tribMun?.tpImunidade),
             ["{{ISS_SUSPENSAO}}"] = GetDescricaoTipoSuspensaoISSQN(infDps.valores?.trib?.tribMun?.exigSusp?.tpSusp),
             ["{{ISS_PROCESSO}}"] = DanfeFallback.OrDash(infDps.valores?.trib?.tribMun?.exigSusp?.nProcesso, warnings, "Número Processo Suspensão", "infNFSe.DPS.InfDPS.valores.trib.tribMun.exigSusp.nProcesso"),
-            ["{{ISS_BENEFICIO}}"] = DanfeFallback.OrDash(infDps.valores?.trib?.tribMun?.BM?.nBM.ToString(), warnings, "Benefício Municipal", "infNFSe.DPS.InfDPS.valores.trib.tribMun.BM.nBM"),
+            ["{{ISS_BENEFICIO}}"] = GetDescricaoBeneficioMunicipal(inf.valores?.tpBM),
             ["{{ISS_DESC_INCOND}}"] = DanfeFallback.OrCurrency(infDps.valores?.vDescCondIncond?.vDescIncond, ptBR, warnings, "vDescIncond", "infNFSe.valores.vDescCondIncond.vDescIncond"),
-            ["{{ISS_DEDUCOES}}"] = DanfeFallback.OrCurrency(inf.valores?.vCalcDR, ptBR, warnings, "vCalcDR", "nfse.infNFSe.valores.vCalcDR"),
-            ["{{ISS_CALCULO}}"] = DanfeFallback.OrCurrency(inf.valores?.vCalcBM, ptBR, warnings, "vCalcBM", "nfse.infNFSe.valores.vCalcBM"),
+            ["{{ISS_DEDUCOES}}"] = FormatCurrency(totalDeducoesReducoes, ptBR),
+            ["{{ISS_CALCULO}}"] = FormatCurrency(calculoBeneficioMunicipal, ptBR),
             ["{{ISS_BC}}"] = DanfeFallback.OrCurrency(inf.valores?.vBC, ptBR, warnings, "vBC", "nfse.infNFSe.valores.vBC"),
             ["{{ISS_ALIQ}}"] = DanfeFallback.OrPercent(vAliqAplic, ptBR, warnings, "pAliqAplic", "infNFSe.valores.pAliqAplic"),
             ["{{ISS_RETENCAO}}"] = GetDescricaoRetencao(tpRetIssqn),
@@ -277,9 +282,9 @@ public sealed class DanfeHtmlRenderer
 
             // Tributação Federal
             ["{{FED_IRRF}}"] = DanfeFallback.OrCurrency(vIRRF, ptBR, warnings, "vIRRF", "infDps.valores.trib.tribFed.vRetIRRF"),
-            ["{{FED_PIS}}"] = DanfeFallback.OrCurrency(vPIS, ptBR, warnings, "vPIS", "infNFSe.valores.trib.tribFed.piscofins.vPis"),
-            ["{{FED_COFINS}}"] = DanfeFallback.OrCurrency(vCOFINS, ptBR, warnings, "vCOFINS", "infDps.valores.trib.tribFed.piscofins.vCofins"),
-            ["{{FED_CSLL}}"] = DanfeFallback.OrCurrency(vCSLL, ptBR, warnings, "vCSLL", "infDps.valores.trib.tribFed.vRetCSLL"),
+            ["{{FED_PIS}}"] = DanfeFallback.OrCurrency(pisDebitoProprio, ptBR, warnings, "vPIS", "infNFSe.valores.trib.tribFed.piscofins.vPis"),
+            ["{{FED_COFINS}}"] = DanfeFallback.OrCurrency(cofinsDebitoProprio, ptBR, warnings, "vCOFINS", "infDps.valores.trib.tribFed.piscofins.vCofins"),
+            ["{{FED_CSLL}}"] = DanfeFallback.OrCurrency(contribuicoesSociaisRetidas, ptBR, warnings, "Contribuicoes Sociais Retidas", "infDps.valores.trib.tribFed"),
             ["{{FED_CP}}"] = DanfeFallback.OrCurrency(vCP, ptBR, warnings, "vCP", "infDps.valores.trib.tribFed.vRetCP"),
             ["{{FED_RET_PISCOFINSCSLL}}"] = GetDescricaoTipoRetencaoPisCofins(infDps.valores?.trib?.tribFed?.piscofins?.tpRetPisCofins),
             //["{{FED_TOTAL}}"] = DanfeFallback.OrCurrency(vTotTribFed, ptBR, warnings, "vTotTribFed", "infDps.valores.trib.totTrib.vTotTrib.vTotTribFed"), //não existe mais no layout novo
@@ -293,10 +298,28 @@ public sealed class DanfeHtmlRenderer
             ["{{FED_RETIDOS}}"] = vTotalRetFed == 0M ? "-" : vTotalRetFed.ToString("C", ptBR),
             ["{{PISCOFINS_DEB}}"] = vDebPisCofins != 0 ? vDebPisCofins.ToString("C", ptBR) : "-",
 
+            ["{{IBSCBS_CST_CLASS}}"] = JoinSlash(ibsCbsDps?.valores?.trib?.gIBSCBS?.CST, ibsCbsDps?.valores?.trib?.gIBSCBS?.cClassTrib),
+            ["{{IBSCBS_INCIDENCIA}}"] = JoinSlash(ibsCbsDps?.cIndOp, ibsCbs?.cLocalidadeIncid, ibsCbs?.xLocalidadeIncid, ResolveUf(ibsCbs?.cLocalidadeIncid)),
+            ["{{IBSCBS_EXCLUSOES}}"] = DanfeFallback.OrCurrency(exclusoesReducaoBase, ptBR, warnings, "Exclusoes e reducoes da base de calculo", "infNFSe.IBSCBS"),
+            ["{{IBSCBS_BC}}"] = DanfeFallback.OrCurrency(valoresIbsCbs?.vBC, ptBR, warnings, "vBC IBS/CBS", "infNFSe.IBSCBS.valores.vBC"),
+            ["{{IBSCBS_REDUCOES}}"] = JoinSlash(FormatPercent(valoresIbsCbs?.uf?.pRedAliqUF, ptBR), FormatPercent(valoresIbsCbs?.mun?.pRedAliqMun, ptBR), FormatPercent(valoresIbsCbs?.fed?.pRedAliqCBS, ptBR)),
+            ["{{IBSCBS_ALIQUOTAS_IBS}}"] = JoinSlash(FormatPercent(valoresIbsCbs?.uf?.pIBSUF, ptBR), FormatPercent(valoresIbsCbs?.mun?.pIBSMun, ptBR)),
+            ["{{IBSCBS_ALIQ_EFET_MUN}}"] = FormatPercent(valoresIbsCbs?.mun?.pAliqEfetMun, ptBR),
+            ["{{IBSCBS_VALOR_MUN}}"] = FormatCurrency(totaisIbsCbs?.gIBS?.gIBSMunTot?.vIBSMun, ptBR),
+            ["{{IBSCBS_ALIQ_EFET_UF}}"] = FormatPercent(valoresIbsCbs?.uf?.pAliqEfetUF, ptBR),
+            ["{{IBSCBS_VALOR_UF}}"] = FormatCurrency(totaisIbsCbs?.gIBS?.gIBSUFTot?.vIBSUF, ptBR),
+            ["{{IBSCBS_TOTAL_IBS}}"] = FormatCurrency(totaisIbsCbs?.gIBS?.vIBSTot, ptBR),
+            ["{{IBSCBS_ALIQ_CBS}}"] = FormatPercent(valoresIbsCbs?.fed?.pCBS, ptBR),
+            ["{{IBSCBS_ALIQ_EFET_CBS}}"] = FormatPercent(valoresIbsCbs?.fed?.pAliqEfetCBS, ptBR),
+            ["{{IBSCBS_TOTAL_CBS}}"] = FormatCurrency(totaisIbsCbs?.gCBS?.vCBS, ptBR),
+            ["{{TOTAL_RETENCOES}}"] = FormatCurrency(inf.valores?.vTotalRet, ptBR),
+            ["{{IBSCBS_TOTAL}}"] = FormatCurrency(totalIbsCbs, ptBR),
+            ["{{IBSCBS_VALOR_TOTAL}}"] = FormatCurrency(totaisIbsCbs?.vTotNF, ptBR),
+
             // Totais tributos é inserido condicionalmente mais abaixo
 
             // Inf complementares
-            ["{{INF_COMPLEMENTARES}}"] = Helper.BuildInfComplementares(infDps.serv, infDps.subst)
+            ["{{INF_COMPLEMENTARES}}"] = Helper.BuildInfComplementares(inf, ptBR)
         };
         // Tomador (condicional)
         foreach (var kv in BuildTomadorMap(infDps, warnings))
@@ -306,11 +329,23 @@ public sealed class DanfeHtmlRenderer
         foreach (var kv in BuildIntermediarioMap(infDps, warnings))
             map[kv.Key] = kv.Value;
 
+        foreach (var kv in BuildDestinatarioMap(infDps, warnings))
+            map[kv.Key] = kv.Value;
+
         // Totais tributos (condicional)
         foreach (var kv in BuildTotaisTributosMap(infDps, ptBR, warnings))
             map[kv.Key] = kv.Value;
 
-        template = Helper.ApplyConditionalSections(template, hasTomador, hasIntermediario);
+        template = Helper.ApplyConditionalSections(
+            template,
+            hasTomador,
+            hasIntermediario,
+            hasDestinatario,
+            destinatarioIsTomador,
+            showPisCofins,
+            issSubject,
+            showIssOptionalRow1,
+            showIssOptionalRow2);
 
         // Aplica os replaces
         foreach (var kv in map)
@@ -341,11 +376,11 @@ public sealed class DanfeHtmlRenderer
 
     private string? GetLogoMunicipio(MunicipiosIbge.Municipio? municipio)
     {
-        var imageCodigoIbge = Path.Combine(AppContext.BaseDirectory, "Assets", "Logos", $"{municipio?.CodigoIbge}.png");
+        var imageCodigoIbge = Path.Combine(_basePath, "Assets", "Logos", $"{municipio?.CodigoIbge}.png");
         if (File.Exists(imageCodigoIbge))
             return Helper.GetLogo(imageCodigoIbge);
 
-        return Helper.GetLogo(Path.Combine(AppContext.BaseDirectory, municipio?.LogoPath ?? string.Empty));
+        return Helper.GetLogo(Path.Combine(_basePath, municipio?.LogoPath ?? string.Empty));
     }
     private Dictionary<string, string> BuildTomadorMap(InfDPS infDps, DanfeWarningCollector warnings)
     {
@@ -354,18 +389,11 @@ public sealed class DanfeHtmlRenderer
 
         return new Dictionary<string, string>
         {
-            ["{{TOMA_CNPJ}}"] =
-                !string.IsNullOrEmpty(infDps.toma.CPF)
-                    ? DanfeFallback.OrDash(
-                        Helper.FormatCpf(infDps.toma.CPF),
-                        warnings,
-                        "CNPJ Tomador",
-                        "infNFSe.DPS.InfDPS.toma.CPF")
-                    : DanfeFallback.OrDash(
-                        Helper.FormatCnpj(infDps.toma.CNPJ),
-                        warnings,
-                        "CNPJ Tomador",
-                        "infNFSe.DPS.InfDPS.toma.CNPJ"),
+            ["{{TOMA_CNPJ}}"] = DanfeFallback.OrDash(
+                Helper.FormatTaxIdentifier(infDps.toma.CNPJ, infDps.toma.CPF, infDps.toma.NIF),
+                warnings,
+                "CNPJ/CPF/NIF Tomador",
+                "infNFSe.DPS.InfDPS.toma"),
 
             ["{{TOMA_IM}}"] = DanfeFallback.OrDash(infDps.toma.IM),
             ["{{TOMA_RAZAO}}"] = DanfeFallback.OrDash(
@@ -381,15 +409,17 @@ public sealed class DanfeHtmlRenderer
                 "infNFSe.DPS.InfDPS.toma.end"),
 
             ["{{TOMA_CEP}}"] = DanfeFallback.OrDash(
-                Helper.FormatCep(infDps.toma.end?.endNac?.CEP),
+                FormatPostalCode(infDps.toma.end),
                 warnings,
                 "CEP Tomador",
-                "infNFSe.DPS.InfDPS.toma.end.endNac.CEP"),
+                "infNFSe.DPS.InfDPS.toma.end"),
 
-            ["{{TOMA_CMUN}}"] = ResolveMunicipioNomeComUf(
-                infDps.toma.end?.endNac?.cMun,
+            ["{{TOMA_CODIGO_CEP}}"] = FormatLocationCodeAndPostalCode(infDps.toma.end),
+
+            ["{{TOMA_CMUN}}"] = ResolveMunicipioOrExternal(
+                infDps.toma.end,
                 warnings,
-                "infNFSe.DPS.InfDPS.toma.end.endNac.cMun"),
+                "infNFSe.DPS.InfDPS.toma.end"),
 
             ["{{TOMA_EMAIL}}"] = DanfeFallback.OrDash(
                 infDps.toma.email,
@@ -411,18 +441,11 @@ public sealed class DanfeHtmlRenderer
 
         return new Dictionary<string, string>
         {
-            ["{{INTER_CNPJ}}"] =
-                !string.IsNullOrEmpty(infDps.interm.CPF)
-                    ? DanfeFallback.OrDash(
-                        Helper.FormatCpf(infDps.interm.CPF),
-                        warnings,
-                        "CNPJ Intermediário",
-                        "infNFSe.DPS.InfDPS.interm.CPF")
-                    : DanfeFallback.OrDash(
-                        Helper.FormatCnpj(infDps.interm.CNPJ),
-                        warnings,
-                        "CNPJ Intermediário",
-                        "infNFSe.DPS.InfDPS.interm.CNPJ"),
+            ["{{INTER_CNPJ}}"] = DanfeFallback.OrDash(
+                Helper.FormatTaxIdentifier(infDps.interm.CNPJ, infDps.interm.CPF, infDps.interm.NIF),
+                warnings,
+                "CNPJ/CPF/NIF Intermediário",
+                "infNFSe.DPS.InfDPS.interm"),
 
             ["{{INTER_IM}}"] = DanfeFallback.OrDash(infDps.interm.IM),
 
@@ -439,15 +462,17 @@ public sealed class DanfeHtmlRenderer
                 "infNFSe.DPS.InfDPS.interm.end"),
 
             ["{{INTER_CEP}}"] = DanfeFallback.OrDash(
-                Helper.FormatCep(infDps.interm.end?.endNac?.CEP),
+                FormatPostalCode(infDps.interm.end),
                 warnings,
                 "CEP Intermediário",
-                "infNFSe.DPS.InfDPS.interm.end.endNac.CEP"),
+                "infNFSe.DPS.InfDPS.interm.end"),
 
-            ["{{INTER_CMUN}}"] = ResolveMunicipioNomeComUf(
-                infDps.interm.end?.endNac?.cMun,
+            ["{{INTER_CODIGO_CEP}}"] = FormatLocationCodeAndPostalCode(infDps.interm.end),
+
+            ["{{INTER_CMUN}}"] = ResolveMunicipioOrExternal(
+                infDps.interm.end,
                 warnings,
-                "infNFSe.DPS.InfDPS.interm.end.endNac.cMun"),
+                "infNFSe.DPS.InfDPS.interm.end"),
 
             ["{{INTER_EMAIL}}"] = DanfeFallback.OrDash(
                 infDps.interm.email,
@@ -460,6 +485,34 @@ public sealed class DanfeHtmlRenderer
                 warnings,
                 "Fone Intermediário",
                 "infNFSe.DPS.InfDPS.interm.fone")
+        };
+    }
+
+    private Dictionary<string, string> BuildDestinatarioMap(InfDPS infDps, DanfeWarningCollector warnings)
+    {
+        var destinatario = infDps.IBSCBS?.dest;
+        if (destinatario == null)
+            return new Dictionary<string, string>();
+
+        int? codigoMunicipio = destinatario.end?.endNac?.cMun;
+        var municipio = codigoMunicipio is > 0 ? MunicipiosIbge.GetMunicipio(codigoMunicipio.Value) : null;
+        var municipioUf = municipio?.NomeComUf;
+        if (string.IsNullOrWhiteSpace(municipioUf) && destinatario.end?.endExt != null)
+            municipioUf = JoinSlash(destinatario.end.endExt.xCidade, destinatario.end.endExt.xEstProvReg);
+
+        return new Dictionary<string, string>
+        {
+            ["{{DEST_CNPJ}}"] = DanfeFallback.OrDash(
+                Helper.FormatTaxIdentifier(destinatario.CNPJ, destinatario.CPF, destinatario.NIF),
+                warnings,
+                "CNPJ/CPF/NIF Destinatario",
+                "infNFSe.DPS.InfDPS.IBSCBS.dest"),
+            ["{{DEST_RAZAO}}"] = DanfeFallback.OrDash(destinatario.xNome),
+            ["{{DEST_ENDERECO}}"] = DanfeFallback.OrDash(Helper.BuildEndereco(destinatario.end)),
+            ["{{DEST_CMUN}}"] = DanfeFallback.OrDash(municipioUf),
+            ["{{DEST_CODIGO_CEP}}"] = FormatLocationCodeAndPostalCode(destinatario.end),
+            ["{{DEST_EMAIL}}"] = DanfeFallback.OrDash(destinatario.email),
+            ["{{DEST_FONE}}"] = DanfeFallback.OrDash(Helper.FormatTelefone(destinatario.fone))
         };
     }
 
@@ -509,6 +562,142 @@ public sealed class DanfeHtmlRenderer
 
         return DanfeFallback.OrDash(mun.NomeComUf, warnings, "NomeComUf", path);
     }
+
+    private static string ResolveMunicipioOrExternal(EndSimples? endereco, DanfeWarningCollector warnings, string path)
+    {
+        if (endereco?.endNac?.cMun is > 0)
+            return ResolveMunicipioNomeComUf(endereco.endNac.cMun, warnings, $"{path}.endNac.cMun");
+
+        if (endereco?.endExt != null)
+            return JoinSlash(endereco.endExt.xCidade, endereco.endExt.xEstProvReg);
+
+        warnings.FieldMissing("cMun/xCidade", path, "-");
+        return "-";
+    }
+
+    private static string FormatPostalCode(EndSimples? endereco) =>
+        endereco?.endNac != null
+            ? Helper.FormatCep(endereco.endNac.CEP)
+            : Helper.NullToDash(endereco?.endExt?.cEndPost);
+
+    private static string FormatLocationCodeAndPostalCode(EndSimples? endereco) =>
+        endereco?.endNac != null
+            ? FormatCodigoCep(endereco.endNac.cMun, endereco.endNac.CEP)
+            : Helper.NullToDash(endereco?.endExt?.cEndPost);
+
+    private static decimal? ResolveIssDeductions(InfDPS infDps, InfNFSe inf, valores? valoresIbsCbs)
+    {
+        if (infDps.valores?.vDedRed?.vDR.HasValue == true)
+            return infDps.valores.vDedRed.vDR;
+
+        if (valoresIbsCbs?.vDR.HasValue == true)
+            return valoresIbsCbs.vDR;
+
+        return SumNullable(inf.valores?.vCalcDR, valoresIbsCbs?.vCalcReeRepRes);
+    }
+
+    private static decimal? CalculateIbsCbsExclusions(params decimal?[] values)
+    {
+        if (!values.Any(value => value.HasValue))
+            return null;
+
+        return values.Sum(value => value ?? 0m);
+    }
+
+    private static decimal? SumNullable(decimal? first, decimal? second)
+    {
+        if (!first.HasValue && !second.HasValue)
+            return null;
+
+        return (first ?? 0m) + (second ?? 0m);
+    }
+
+    private static string FormatCurrency(decimal? value, CultureInfo culture) =>
+        value.HasValue ? value.Value.ToString("C", culture) : "-";
+
+    private static string FormatPercent(decimal? value, CultureInfo culture) =>
+        value.HasValue ? $"{value.Value.ToString("N2", culture)}%" : "-";
+
+    private static string FormatTributacaoCode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) return "-";
+        return Regex.Replace(value, @"^(\d{2})(\d{2})(\d{2})$", "$1.$2.$3");
+    }
+
+    private static string JoinSlash(params string?[] values) =>
+        string.Join(" / ", values.Select(value => string.IsNullOrWhiteSpace(value) ? "-" : value));
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+
+    private static string FormatMunicipioUf(string? municipio, string? uf) =>
+        JoinSlash(municipio, uf);
+
+    private static string FormatCodigoCep(string? codigo, string? cep) =>
+        JoinSlash(codigo, Helper.FormatCep(cep));
+
+    private static string FormatCodigoCep(int? codigo, string? cep) =>
+        FormatCodigoCep(codigo is > 0 ? codigo.Value.ToString(CultureInfo.InvariantCulture) : null, cep);
+
+    private static string? ResolveUf(string? codigoMunicipio)
+    {
+        if (!int.TryParse(codigoMunicipio, out var codigo)) return null;
+        return MunicipiosIbge.GetMunicipio(codigo)?.Uf;
+    }
+
+    private static string BuildWatermark(string text) => $@"<div style=""
+              position:absolute;
+              top:50%;
+              left:50%;
+              display:inline-block;
+              -webkit-transform: translate(-50%, -50%) rotate(-30deg);
+              transform: translate(-50%, -50%) rotate(-30deg);
+              -webkit-transform-origin: 50% 50%;
+              transform-origin: 50% 50%;
+              font-family: Arial, 'Liberation Sans', Helvetica, sans-serif;
+              font-size:50pt;
+              font-weight:normal;
+              color:#a6a6a6;
+              z-index:9999;
+              pointer-events:none;
+              white-space:nowrap;"">{Helper.HtmlEncode(text)}</div>";
+
+    private static string GetDescricaoAmbienteGerador(int ambiente) => ambiente switch
+    {
+        1 => "Prefeitura",
+        2 => "Sistema Nacional da NFS-e",
+        _ => "-"
+    };
+
+    private static string GetDescricaoTipoAmbiente(int ambiente) => ambiente switch
+    {
+        1 => "Produção",
+        2 => "Produção Restrita",
+        _ => "-"
+    };
+
+    private static string GetDescricaoEmitenteV2(int emitente) => emitente switch
+    {
+        1 => "Prestador",
+        2 => "Tomador",
+        3 => "Intermediário",
+        _ => "-"
+    };
+
+    private static string GetDescricaoSituacao(int situacao) => situacao switch
+    {
+        100 => "NFS-e Gerada",
+        102 => "NFS-e de Decisão Judicial",
+        103 => "NFS-e Avulsa",
+        107 => "NFS-e MEI",
+        _ => situacao > 0 ? situacao.ToString(CultureInfo.InvariantCulture) : "-"
+    };
+
+    private static string GetDescricaoFinalidade(int? finalidade) => finalidade switch
+    {
+        0 => "NFS-e regular",
+        _ => "-"
+    };
 
     private string GetDescricaoRetencao(int? tpRetISSQN)
     {
@@ -662,10 +851,21 @@ public sealed class DanfeHtmlRenderer
                 return "Profissional Autônomo";
             case 6:
                 return "Sociedade de Profissionais";
+            case 9:
+                return "Outros";
             default:
                 return "-";
         }
     }
+
+    private static string GetDescricaoBeneficioMunicipal(string? tipo) => tipo switch
+    {
+        "1" => "Isenção",
+        "2" => "Redução da base de cálculo em percentual",
+        "3" => "Redução da base de cálculo em valor",
+        "4" => "Alíquota diferenciada",
+        _ => "-"
+    };
 
     private string GetDescricaoTipoImunidade(int? tpImunidade)
     {

--- a/src/Danfe/Schemas/NFSeSchema.cs
+++ b/src/Danfe/Schemas/NFSeSchema.cs
@@ -259,7 +259,15 @@ namespace Direction.NFSe.Danfe
     {
         public string? idDocTec { get; set; }
         public string? docRef { get; set; }
+        public string? xPed { get; set; }
+        public InfoItemPedido? gItemPed { get; set; }
         public string? xInfComp { get; set; }
+    }
+
+    public class InfoItemPedido
+    {
+        [XmlElement("xItemPed")]
+        public List<string> xItemPed { get; set; } = [];
     }
 
     public class CServ
@@ -332,12 +340,14 @@ namespace Direction.NFSe.Danfe
 
     public class VDedRed
     {
-        public decimal pDR { get; set; }
-        public decimal vDR { get; set; }
+        public decimal? pDR { get; set; }
+        public decimal? vDR { get; set; }
 
         [XmlArray("documentos")]
         public List<Documento>? documentos { get; set; }
 
+        public bool ShouldSerializepDR() => pDR.HasValue;
+        public bool ShouldSerializevDR() => vDR.HasValue;
         public bool ShouldSerializedocumentos() => documentos != null && documentos.Count > 0;
     }
 
@@ -440,6 +450,15 @@ namespace Direction.NFSe.Danfe
         public decimal vTotTribFed { get; set; }
         public decimal vTotTribEst { get; set; }
         public decimal vTotTribMun { get; set; }
+
+        [XmlIgnore]
+        public bool vTotTribFedSpecified { get; set; }
+
+        [XmlIgnore]
+        public bool vTotTribEstSpecified { get; set; }
+
+        [XmlIgnore]
+        public bool vTotTribMunSpecified { get; set; }
     }
 
     public class TotTrib
@@ -464,6 +483,11 @@ namespace Direction.NFSe.Danfe
         public dest? dest { get; set; }
         public imovel? imovel { get; set; }
         public valores? valores { get; set; }
+
+        // Campos calculados presentes no grupo IBSCBS da NFS-e autorizada.
+        public string? cLocalidadeIncid { get; set; }
+        public string? xLocalidadeIncid { get; set; }
+        public TotCIBS? totCIBS { get; set; }
     }
 
     public class gRefNFSe
@@ -515,6 +539,14 @@ namespace Direction.NFSe.Danfe
     {
         public gReeRepRes? gReeRepRes { get; set; }
         public trib? trib { get; set; }
+
+        // Resultado da apuracao do IBS/CBS na NFS-e autorizada.
+        public decimal? vBC { get; set; }
+        public decimal? vCalcReeRepRes { get; set; }
+        public decimal? vDR { get; set; }
+        public ValoresIbsUf? uf { get; set; }
+        public ValoresIbsMun? mun { get; set; }
+        public ValoresCbs? fed { get; set; }
     }
 
     public class gReeRepRes
@@ -592,5 +624,55 @@ namespace Direction.NFSe.Danfe
         public int pDifUF { get; set; }
         public int pDifMun { get; set; }
         public int pDifCBS { get; set; }
+    }
+
+    public class ValoresIbsUf
+    {
+        public decimal? pRedAliqUF { get; set; }
+        public decimal? pIBSUF { get; set; }
+        public decimal? pAliqEfetUF { get; set; }
+    }
+
+    public class ValoresIbsMun
+    {
+        public decimal? pRedAliqMun { get; set; }
+        public decimal? pIBSMun { get; set; }
+        public decimal? pAliqEfetMun { get; set; }
+    }
+
+    public class ValoresCbs
+    {
+        public decimal? pRedAliqCBS { get; set; }
+        public decimal? pCBS { get; set; }
+        public decimal? pAliqEfetCBS { get; set; }
+    }
+
+    public class TotCIBS
+    {
+        public decimal? vTotNF { get; set; }
+        public TotaisIbs? gIBS { get; set; }
+        public TotaisCbs? gCBS { get; set; }
+    }
+
+    public class TotaisIbs
+    {
+        public decimal? vIBSTot { get; set; }
+        public TotalIbsUf? gIBSUFTot { get; set; }
+        public TotalIbsMun? gIBSMunTot { get; set; }
+    }
+
+    public class TotalIbsUf
+    {
+        public decimal? vIBSUF { get; set; }
+    }
+
+    public class TotalIbsMun
+    {
+        public decimal? vIBSMun { get; set; }
+    }
+
+    public class TotaisCbs
+    {
+        public decimal? vCBS { get; set; }
     }
 }

--- a/tests/Danfe.Tests/Danfe.Tests.csproj
+++ b/tests/Danfe.Tests/Danfe.Tests.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Fixtures\" />
+    <None Include="Fixtures\*.xml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
 </Project>

--- a/tests/Danfe.Tests/Fixtures/nfse-ibscbs.xml
+++ b/tests/Danfe.Tests/Fixtures/nfse-ibscbs.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<NFSe xmlns="http://www.sped.fazenda.gov.br/nfse" versao="1.01">
+  <infNFSe Id="NFS32052001220616143000130000000000949826079999999999">
+    <xLocEmi>LocalEmissao</xLocEmi>
+    <xLocPrestacao>Prestacao</xLocPrestacao>
+    <nNFSe>9999</nNFSe>
+    <cLocIncid>3288888</cLocIncid>
+    <xLocIncid>Municipio</xLocIncid>
+    <xTribNac>Processamento de dados, textos, imagens, vídeos e sistemas de informação.</xTribNac>
+    <verAplic>SilTecnologia_v1.00</verAplic>
+    <ambGer>1</ambGer>
+    <tpEmis>2</tpEmis>
+    <cStat>100</cStat>
+    <dhProc>2026-07-01T00:00:00-03:00</dhProc>
+    <nDFSe>64463999</nDFSe>
+    <emit>
+      <CNPJ>20616143999999</CNPJ>
+      <IM>279999</IM>
+      <xNome>PRESTADOR LTDA</xNome>
+      <enderNac><xLgr>RODOVIA DO SOL</xLgr><nro>2070</nro><xBairro>Bairro</xBairro><cMun>3208888</cMun><UF>ES</UF><CEP>29122222</CEP></enderNac>
+      <fone>27998489999</fone>
+      <email>TESTE@TESTE.COM.BR</email>
+    </emit>
+    <valores><vBC>1390.17</vBC><pAliqAplic>2.50</pAliqAplic><vISSQN>34.75</vISSQN><vLiq>1390.17</vLiq></valores>
+    <IBSCBS>
+      <cLocalidadeIncid>99888888</cLocalidadeIncid>
+      <xLocalidadeIncid>Localidade</xLocalidadeIncid>
+      <valores>
+        <vBC>1304.67</vBC>
+        <uf><pIBSUF>0.10</pIBSUF><pAliqEfetUF>0.00</pAliqEfetUF></uf>
+        <mun><pIBSMun>0.00</pIBSMun><pAliqEfetMun>0.00</pAliqEfetMun></mun>
+        <fed><pCBS>0.90</pCBS><pAliqEfetCBS>0.00</pAliqEfetCBS></fed>
+      </valores>
+      <totCIBS>
+        <vTotNF>1390.17</vTotNF>
+        <gIBS><vIBSTot>1.30</vIBSTot><gIBSUFTot><vIBSUF>1.30</vIBSUF></gIBSUFTot><gIBSMunTot><vIBSMun>0.00</vIBSMun></gIBSMunTot></gIBS>
+        <gCBS><vCBS>11.74</vCBS></gCBS>
+      </totCIBS>
+    </IBSCBS>
+    <DPS versao="1.01">
+      <infDPS Id="DPS320520022061614300013000002000000000000000">
+        <tpAmb>1</tpAmb><dhEmi>2026-07-01T00:00:00-03:00</dhEmi><verAplic>SilTecnologia_v1.00</verAplic><serie>2</serie><nDPS>68888</nDPS><dCompet>2026-07-01</dCompet><tpEmit>1</tpEmit><cLocEmi>3288888</cLocEmi>
+        <prest><CNPJ>20699993000000</CNPJ><IM>273999</IM><fone>27999999999</fone><email>ADMINISTRATIVO@TESTE.COM.BR</email><regTrib><opSimpNac>1</opSimpNac><regEspTrib>0</regEspTrib></regTrib></prest>
+        <toma><CNPJ>09999999900154</CNPJ><xNome>NOMETOMADOR</xNome><end><endNac><cMun>3209999</cMun><CEP>29088888</CEP></endNac><xLgr>Logradouro</xLgr><nro>134</nro><xBairro>Bairro</xBairro></end><email>teste@teste.com.br</email></toma>
+        <serv><locPrest><cLocPrestacao>55222555</cLocPrestacao></locPrest><cServ><cTribNac>010301</cTribNac><xDescServ>SUPORTE SQL SERVER</xDescServ><cNBS>115061000</cNBS></cServ><infoCompl><docRef>documento-123</docRef></infoCompl></serv>
+        <valores>
+          <vServPrest><vServ>1390.17</vServ></vServPrest>
+          <trib><tribMun><tribISSQN>1</tribISSQN><tpRetISSQN>1</tpRetISSQN></tribMun><tribFed><piscofins><CST>01</CST><vPis>9.04</vPis><vCofins>41.71</vCofins><tpRetPisCofins>0</tpRetPisCofins></piscofins></tribFed><totTrib><vTotTrib><vTotTribFed>0.00</vTotTribFed><vTotTribEst>0.00</vTotTribEst><vTotTribMun>34.75</vTotTribMun></vTotTrib></totTrib></trib>
+        </valores>
+        <IBSCBS><finNFSe>0</finNFSe><cIndOp>100301</cIndOp><indDest>0</indDest><valores><trib><gIBSCBS><CST>000</CST><cClassTrib>000001</cClassTrib></gIBSCBS></trib></valores></IBSCBS>
+      </infDPS>
+    </DPS>
+  </infNFSe>
+</NFSe>

--- a/tests/Danfe.Tests/GoldenHtmlTests.cs
+++ b/tests/Danfe.Tests/GoldenHtmlTests.cs
@@ -1,21 +1,232 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using System.Xml.Serialization;
 using Direction.NFSe.Danfe;
 using Xunit;
+
+namespace Danfe.Tests;
 
 public class GoldenHtmlTests
 {
     [Fact]
-    public void Html_snapshot_should_match()
+    public void Render_Nt008Xml_RendersDanfeV2WithIbsCbsValues()
     {
-        // TODO: Criar as notas fiscais eletrônicas de serviço (NFS-e) de testes
-        var service = new DanfeService(); ;
-        //var result = service.Generate(File.ReadAllText("Fixtures/nfse.xml"), DanfeEnvironment.Production);
+        var nfse = LoadFixture();
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
 
-        //var normalized = HtmlNormalization.Normalize(result.Html);
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+        var normalized = HtmlNormalization.Normalize(html);
 
-        //var approvedPath = Path.Combine("Approved", "nfse.approved.html");
-        //var approved = File.ReadAllText(approvedPath);
-        var approved = "";
-        var normalized = "";
-        Assert.Equal(approved, normalized);
+        Assert.Contains("DANFSe v2.0", normalized);
+        Assert.Contains("NFS-e Gerada", normalized);
+        Assert.Contains("NFS-e regular", normalized);
+        Assert.Contains("Ambiente Gerador: 1", normalized);
+        Assert.Contains("Tipo de Ambiente: 1", normalized);
+        Assert.Matches(
+            new Regex(@"\.c-qr img\s*\{\s*width:\s*15\.4mm;\s*height:\s*15\.4mm;", RegexOptions.IgnoreCase),
+            normalized);
+        Assert.Contains("000 / 000001", normalized);
+        Assert.Contains("100301 / 99888888 / Localidade / -", normalized);
+        Assert.Contains("R$ 85,50", NormalizeCurrencySpacing(normalized));
+        Assert.Contains("R$ 1.304,67", NormalizeCurrencySpacing(normalized));
+        Assert.Contains("0,10% / 0,00%", normalized);
+        Assert.Contains("R$ 1,30", NormalizeCurrencySpacing(normalized));
+        Assert.Contains("R$ 11,74", NormalizeCurrencySpacing(normalized));
+        Assert.Contains("R$ 13,04", NormalizeCurrencySpacing(normalized));
+        Assert.Contains("O DESTINATÁRIO É O PRÓPRIO TOMADOR/ADQUIRENTE DA OPERAÇÃO", normalized);
+        Assert.Contains("Totais Aproximados dos Tributos cfe. Lei nº 12.741/2012", normalized);
+        Assert.DoesNotContain("Regime Especial de Tributação ISSQN", normalized);
+        Assert.DoesNotContain("Benefício Municipal", normalized);
+        Assert.Matches(
+            new Regex(@"<tr class=""sec-title"">\s*<td class=""sec-title-label"">Prestador / Fornecedor</td>\s*<td", RegexOptions.IgnoreCase),
+            html);
+        Assert.DoesNotContain("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=", html);
+        Assert.DoesNotMatch(new Regex(@"\{\{[^}]+\}\}"), normalized);
     }
+
+    [Fact]
+    public void Render_PisCofinsRetained_MovesValuesToSocialContributions()
+    {
+        var nfse = LoadFixture();
+        var pisCofins = nfse.infNFSe!.DPS!.InfDPS!.valores!.trib!.tribFed!.piscofins!;
+        pisCofins.tpRetPisCofins = 1;
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+        var normalized = NormalizeCurrencySpacing(NormalizeRenderedHtml(html));
+
+        Assert.Contains("R$ 50,75", normalized);
+        Assert.True(Regex.Matches(normalized, "R\\$ 0,00").Count >= 2);
+    }
+
+    [Fact]
+    public void Render_CompetenceAfter2026_OmitsPisCofinsDebitRow()
+    {
+        var nfse = LoadFixture();
+        nfse.infNFSe!.DPS!.InfDPS!.dCompet = "2027-01-01";
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+
+        Assert.DoesNotContain("PIS - Débito Apuração Própria", html);
+        Assert.DoesNotContain("COFINS - Débito Apuração Própria", html);
+    }
+
+    [Fact]
+    public void Render_OptionalIssData_RendersItsRows()
+    {
+        var nfse = LoadFixture();
+        nfse.infNFSe!.DPS!.InfDPS!.prest!.regTrib!.regEspTrib = 1;
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+
+        Assert.Contains("Regime Especial de Tributação ISSQN", html);
+    }
+
+    [Fact]
+    public void Render_NotSubjectToIss_RendersOnlyTheRequiredMessage()
+    {
+        var nfse = LoadFixture();
+        nfse.infNFSe!.DPS!.InfDPS!.valores!.trib!.tribMun!.tribISSQN = 4;
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+
+        Assert.Contains("TRIBUTAÇÃO MUNICIPAL (ISSQN) - OPERAÇÃO NÃO SUJEITA AO ISSQN", html);
+        Assert.DoesNotContain("Tipo de Tributação do ISSQN", html);
+        Assert.DoesNotContain("BC ISSQN", html);
+    }
+
+    [Fact]
+    public void Render_MunicipalBenefitAndDeductions_UsesAuthorizedNfseValues()
+    {
+        var nfse = LoadFixture();
+        var inf = nfse.infNFSe!;
+        inf.valores!.tpBM = "2";
+        inf.valores.vCalcBM = 20m;
+        inf.IBSCBS!.valores!.vDR = 30m;
+        inf.DPS!.InfDPS!.prest!.regTrib!.regEspTrib = 9;
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+        var normalized = NormalizeCurrencySpacing(NormalizeRenderedHtml(html));
+
+        Assert.Contains("Redução da base de cálculo em percentual", normalized);
+        Assert.Contains("R$ 20,00", normalized);
+        Assert.Contains("R$ 30,00", normalized);
+        Assert.Contains("Outros", normalized);
+    }
+
+    [Fact]
+    public void Render_TaxDescriptions_PrefersMunicipalDescription()
+    {
+        var nfse = LoadFixture();
+        nfse.infNFSe!.xTribNac = "Descrição nacional";
+        nfse.infNFSe.xTribMun = "Descrição municipal";
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+
+        var normalized = NormalizeRenderedHtml(html);
+        Assert.Contains("Descrição municipal", normalized);
+        Assert.DoesNotContain("Descrição nacional", normalized);
+    }
+
+    [Fact]
+    public void Render_ForeignIntermediaryAndPurchaseOrder_PreservesNationalModelFields()
+    {
+        var nfse = LoadFixture();
+        var infDps = nfse.infNFSe!.DPS!.InfDPS!;
+        infDps.interm = new Intermediario
+        {
+            NIF = "PT-123456",
+            xNome = "Intermediário Exterior",
+            end = new EndSimples
+            {
+                xLgr = "Rua Internacional",
+                nro = "10",
+                endExt = new EndExt
+                {
+                    xCidade = "Lisboa",
+                    xEstProvReg = "Lisboa",
+                    cEndPost = "1000-001"
+                }
+            }
+        };
+        infDps.serv!.infoCompl ??= new infoCompl();
+        infDps.serv.infoCompl.xPed = "PED-123";
+        infDps.serv.infoCompl.gItemPed = new InfoItemPedido { xItemPed = ["10", "20"] };
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+        var normalized = NormalizeRenderedHtml(html);
+
+        Assert.Contains("PT-123456", normalized);
+        Assert.Contains("Lisboa / Lisboa", normalized);
+        Assert.Contains("1000-001", normalized);
+        Assert.DoesNotContain("- / 1000-001", normalized);
+        Assert.Contains("Núm. Ped.: PED-123", normalized);
+        Assert.Contains("Item Ped.: 10, 20", normalized);
+    }
+
+    [Fact]
+    public void Render_LongDescriptions_TruncatesWithEllipsisAndKeepsTaxTotals()
+    {
+        var nfse = LoadFixture();
+        var infDps = nfse.infNFSe!.DPS!.InfDPS!;
+        infDps.serv!.cServ!.xDescServ = new string('S', 1400);
+        infDps.serv.infoCompl ??= new infoCompl();
+        infDps.serv.infoCompl.xInfComp = new string('I', 2100);
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+
+        Assert.Contains("...", html);
+        Assert.DoesNotContain(new string('S', 1300), html);
+        Assert.DoesNotContain(new string('I', 1997), html);
+        Assert.Contains("Totais Aproximados dos Tributos", html);
+    }
+
+    [Fact]
+    public void Render_PercentageDeduction_UsesCalculatedAuthorizedValue()
+    {
+        var nfse = LoadFixture();
+        var inf = nfse.infNFSe!;
+        inf.DPS!.InfDPS!.valores!.vDedRed = new VDedRed { pDR = 10m };
+        inf.valores!.vCalcDR = 45m;
+        inf.IBSCBS!.valores!.vDR = null;
+
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Autorizada);
+        var normalized = NormalizeCurrencySpacing(NormalizeRenderedHtml(html));
+
+        Assert.Contains("R$ 45,00", normalized);
+    }
+
+    [Fact]
+    public void Render_Cancelled_UsesNt008WatermarkStyle()
+    {
+        var nfse = LoadFixture();
+        var renderer = new DanfeHtmlRenderer(new DanfeOptions());
+
+        var (html, _) = renderer.Render(nfse, DanfeEnvironment.Production, DanfeStatus.Cancelada);
+
+        Assert.Contains("font-size:50pt", html);
+        Assert.Contains("font-weight:normal", html);
+        Assert.Contains("color:#a6a6a6", html);
+        Assert.DoesNotContain("border: 8px", html);
+    }
+
+    private static NFSeSchema LoadFixture()
+    {
+        var path = Path.Combine(AppContext.BaseDirectory, "Fixtures", "nfse-ibscbs.xml");
+        using var stream = File.OpenRead(path);
+        var serializer = new XmlSerializer(typeof(NFSeSchema));
+        return Assert.IsType<NFSeSchema>(serializer.Deserialize(stream));
+    }
+
+    private static string NormalizeCurrencySpacing(string value) => value.Replace('\u00a0', ' ');
+
+    private static string NormalizeRenderedHtml(string html) => WebUtility.HtmlDecode(HtmlNormalization.Normalize(html));
 }


### PR DESCRIPTION
## O que mudou

- substitui o `NReco.PdfGenerator` pelo `DinkToPdf` e inclui o runtime nativo Linux do `wkhtmltox`;
- mantém `net48` e `netstandard2.0` e adiciona suporte explícito a `net10.0`;
- adiciona `IDanfeService` e preserva as sobrecargas legadas de geração;
- atualiza schema, renderer e template para o DANFSe v2 da Nota Técnica SE/CGNFS-e nº 008;
- inclui campos e totais de IBS/CBS, regras condicionais do ISSQN, NIF/endereço estrangeiro, benefícios, deduções, pedidos e marca-d'água;
- corrige o encolhimento automático do `wkhtmltopdf`, mantendo o documento em uma página A4 e o QR Code no tamanho mínimo exigido;
- adiciona fixture XML com IBS/CBS e testes de regressão do HTML gerado.

## Motivação

O gerador anterior dependia do `NReco.PdfGenerator`, que não funciona em implantações Linux, e o modelo/schema ainda não contemplava integralmente o DANFSe v2 e os campos da reforma tributária. Além disso, o encolhimento inteligente do `wkhtmltopdf` reduzia o conteúdo e deixava uma área considerável da página sem uso.

## Impacto

A biblioteca passa a gerar o DANFSe localmente em Linux e .NET 10, sem depender da API externa do ADN, preservando os targets legados do pacote. O layout segue a estrutura do novo modelo nacional e degrada campos ausentes de forma segura.

## Validação

- `dotnet build Danfe.sln -c Release --no-restore`: 0 erros;
- `dotnet test Danfe.sln -c Release --no-build`: 14/14 testes aprovados;
- `dotnet-format --check`: aprovado;
- `npm run format:check`: aprovado;
- geração real em container Linux com `wkhtmltopdf 0.12.4`: PDF A4 de uma página, inspecionado visualmente.

O restore ainda reporta avisos `NU1903` vindos das dependências transitivas legadas do `DinkToPdf` (`System.Net.Http` e `System.Security.Cryptography.X509Certificates`); eles não impedem o build e ficam explícitos para avaliação dos mantenedores.

Closes #7
Closes #20
